### PR TITLE
Split numeric vectors of lat/lng into lists for polygons automatically

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -167,7 +167,6 @@ addCircles = function(
     expandLimits(pts$lat, pts$lng)
 }
 
-# WARNING: lat and lng are LISTS of latitude and longitude vectors
 #' @export
 addPolylines = function(
   map, lng = NULL, lat = NULL, layerId = NULL,
@@ -187,6 +186,9 @@ addPolylines = function(
   options = makeOpts(match.call(), c("map", "lng", "lat", "layerId", "data"))
   lng = resolveFormula(lng, data)
   lat = resolveFormula(lat, data)
+  latlng = makePolyList(lat, lng)
+  lat = latlng$lat
+  lng = latlng$lng
   appendMapData(map, data, 'polyline', lat, lng, layerId, options) %>%
     expandLimits(unlist(lat), unlist(lng))
 }
@@ -219,7 +221,6 @@ addRectangles = function(
     expandLimits(c(lat1, lat2), c(lng1, lng2))
 }
 
-# WARNING: lat and lng are LISTS of latitude and longitude vectors
 #' @export
 addPolygons = function(
   map, lng = NULL, lat = NULL, layerId = NULL,
@@ -242,6 +243,9 @@ addPolygons = function(
   options = makeOpts(match.call(), c("map", "lng", "lat", "layerId", "data"))
   lng = resolveFormula(lng, data)
   lat = resolveFormula(lat, data)
+  latlng = makePolyList(lat, lng)
+  lat = latlng$lat
+  lng = latlng$lng
   appendMapData(map, data, 'polygon', lat, lng, layerId, options) %>%
     expandLimits(unlist(lat), unlist(lng))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,3 +12,18 @@ appendMapData = function(map, data, component, ...) {
   map$x[[component]] = x
   map
 }
+
+makePolyList = function(lat, lng) {
+  if (!identical(class(lat), class(lng)))
+    stop("'lat' and 'lng' must be of the same class")
+  if (is.list(lat) && is.list(lng)) return(list(lat = lat, lng = lng))
+  if (!is.numeric(lat) || !is.numeric(lng))
+    stop("Both 'lat' and 'lng' must be numeric vectors")
+  i = is.na(lat) | is.na(lng)
+  if (!any(i)) return(list(lat = list(lat), lng = list(lng)))
+  chunks = cumsum(i)[!i]
+  list(
+    lat = unname(split(lat[!i], chunks)),
+    lng = unname(split(lng[!i], chunks))
+  )
+}

--- a/inst/examples/leaflet.R
+++ b/inst/examples/leaflet.R
@@ -40,6 +40,10 @@ m %>% addPolylines(rand_lng(50), rand_lat(50))
 
 # polygon
 m %>% addPolygons(rand_lng(), rand_lat(), layerId = 'foo')
+m %>% addPolygons(
+  rand_lng(20), c(rand_lat(5), NA, rand_lat(6), NA, rand_lat(7)),
+  color = c('red', 'blue', 'yellow')
+)
 
 # geoJSON
 seattle_geojson <- list(

--- a/man/leaflet.Rd
+++ b/man/leaflet.Rd
@@ -65,6 +65,10 @@ m \%>\% addPolylines(rand_lng(50), rand_lat(50))
 
 # polygon
 m \%>\% addPolygons(rand_lng(), rand_lat(), layerId = 'foo')
+m \%>\% addPolygons(
+  rand_lng(20), c(rand_lat(5), NA, rand_lat(6), NA, rand_lat(7)),
+  color = c('red', 'blue', 'yellow')
+)
 
 # geoJSON
 seattle_geojson <- list(


### PR DESCRIPTION
I guess the convention of using NA to separate polygons in R is fine, and this PR converts numeric vectors into lists internally.

![screenshot from 2014-12-09 15 57 38](https://cloud.githubusercontent.com/assets/163582/5366760/12776742-7fbc-11e4-90c3-77b9f56a678b.png)
