### PR TITLE
Handle click and bounds update events only once

### DIFF
--- a/R/leaflet.R
+++ b/R/leaflet.R
@@ -16,8 +16,6 @@
 #'   \code{Polygons}, \code{SpatialPolygons}, \code{SpatialPolygonsDataFrame},
 #'   \code{Line}, \code{Lines}, \code{SpatialLines}, and
 #'   \code{SpatialLinesDataFrame})
-#' @param id a character string as the identifier of the map (you do not need to
-#'   provide it unless you want to manipulate the map later in Shiny)
 #' @param width the width of the map
 #' @param height the height of the map
 #' @param padding the padding of the map
@@ -25,11 +23,11 @@
 #'   \code{\%>\%} (see examples).
 #' @example inst/examples/leaflet.R
 #' @export
-leaflet = function(data = NULL, id = NULL, width = NULL, height = NULL, padding = 0) {
+leaflet = function(data = NULL, width = NULL, height = NULL, padding = 0) {
   htmlwidgets::createWidget(
     'leaflet',
     structure(
-      list(mapId = id),
+      list(),
       leafletData = data
     ),
     width = width, height = height,

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -519,8 +519,7 @@ var dataframe = (function() {
           methods[call.method].apply(map, call.args);
       }
 
-      var id = data.mapId;
-      if (id === null) return;
+      var id = this.getId(el);
       maps[id] = map;
 
       if (!HTMLWidgets.shinyMode) return;

--- a/man/leaflet.Rd
+++ b/man/leaflet.Rd
@@ -3,7 +3,7 @@
 \alias{leaflet}
 \title{Create a Leaflet map widget}
 \usage{
-leaflet(data = NULL, id = NULL, width = NULL, height = NULL, padding = 0)
+leaflet(data = NULL, width = NULL, height = NULL, padding = 0)
 }
 \arguments{
 \item{data}{a data object (currently supported objects are matrices, data
@@ -12,9 +12,6 @@ frames, and spatial objects from the \pkg{sp} package of classes
 \code{Polygons}, \code{SpatialPolygons}, \code{SpatialPolygonsDataFrame},
 \code{Line}, \code{Lines}, \code{SpatialLines}, and
 \code{SpatialLinesDataFrame})}
-
-\item{id}{a character string as the identifier of the map (you do not need to
-provide it unless you want to manipulate the map later in Shiny)}
 
 \item{width}{the width of the map}
 


### PR DESCRIPTION
Fixes #29. Click and bounds-update event handlers will only be registered once per map. Previously, each time a data update was received from the server, an additional click and bounds-udpate event handler was added.

This also adds a set of functions for managing event handlers. Leaflet doesn't support event namespacing; the new functions provide that functionality.