### PR TITLE
Feature/events

### DIFF
--- a/R/events.R
+++ b/R/events.R
@@ -1,0 +1,25 @@
+#' Methods to add event listener map widget
+#'
+#' A series of methods to manipulate the map.
+#' @param map a map widget object created from \code{\link{leaflet}()}
+#' @param ... any arguments with names equal to event name, and value to javascript function. See example.
+#' @references \url{http://leafletjs.com/reference.html#map-click}
+#' @return The modified map widget.
+#' @export
+#' @examples library(leaflet)
+#' m = leaflet() %>% addTiles() %>% setView(-93.65, 42.0285, zoom = 17) %>%
+#'  addEventListener(click ="function(e) {alert('click');}",
+#'  zoomend ="function(e) {alert('zoomend');}")
+#'  m
+addEventListener = function(map, ...) {
+
+  list.event <- list(...)
+
+  list.event <- lapply(names(list.event), function(x){
+    list(method = x, event = JS(list.event[[x]]))
+  })
+
+  map$x$addEventListener = list.event
+
+  map
+}

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -530,6 +530,11 @@ var dataframe = (function() {
         methods.fitBounds.apply(map, data.fitBounds);
       }
 
+      // set event
+      for (var i = 0; data.addEventListener && i < data.addEventListener.length; i++) {
+        map.on(data.addEventListener[i].method, data.addEventListener[i].event);
+      }
+
       // Returns true if the zoomToLimits option says that the map should be
       // zoomed to map elements.
       function needsZoom() {


### PR DESCRIPTION
Linked with  Available use of leaflet event #37 issue, can we think about something like that to enable user to set all event he want ?

http://leafletjs.com/reference.html#map-click

Then, we can do with a basic example : 

```
m = leaflet() %>% addTiles() %>% setView(-93.65, 42.0285, zoom = 17) %>%
 addEventListener(click ="function(e) {alert('click');}",
 zoomend ="function(e) {alert('zoomend');}")
```

addEventListener is actually write very quickly just to test, we can add more verificiations...
