### PR TITLE
add GitHub ribbon

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,8 @@ img {
 <h4 class="date"><em>2015-05-06</em></h4>
 </div>
 
+<a href="https://github.com/rstudio/leaflet"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
+
 <div id="TOC">
 <ul>
 <li><a href="#installation-and-use"><span class="toc-section-number">1</span> Installation and Use</a></li>


### PR DESCRIPTION
There's no link back to the GitHub project on the web page. Ribbon is overused but gets the job done.