### PR TITLE
Use CIE-Lab color interpolation instead of RGB

### DIFF
--- a/R/colors.R
+++ b/R/colors.R
@@ -258,7 +258,7 @@ NULL
 
 
 safePaletteFunc = function(pal, na.color) {
-  toPaletteFunc(pal) %>% filterRGB() %>% filterNA(na.color) %>% filterRange()
+  toPaletteFunc(pal) %>% filterRGB() %>% filterZeroLength() %>% filterNA(na.color) %>% filterRange()
 }
 
 toPaletteFunc = function(pal) {
@@ -270,11 +270,12 @@ toPaletteFunc = function(pal) {
 toPaletteFunc.character = function(pal) {
   if (length(pal) == 1 && pal %in% row.names(RColorBrewer::brewer.pal.info)) {
     return(grDevices::colorRamp(
-      RColorBrewer::brewer.pal(RColorBrewer::brewer.pal.info[pal, 'maxcolors'], pal)
+      RColorBrewer::brewer.pal(RColorBrewer::brewer.pal.info[pal, 'maxcolors'], pal),
+      space = 'Lab'
     ))
   }
 
-  grDevices::colorRamp(pal)
+  grDevices::colorRamp(pal, space = 'Lab')
 }
 
 # Accept colorRamp style matrix
@@ -319,6 +320,19 @@ previewColors = function(pal, values) {
       )
     ))
   )
+}
+
+# colorRamp(space = 'Lab') throws error when called with
+# zero-length input
+filterZeroLength = function(f) {
+  force(f)
+  function(x) {
+    if (length(x) == 0) {
+      character(0)
+    } else {
+      f(x)
+    }
+  }
 }
 
 # Wraps an underlying non-NA-safe function (like colorRamp).

--- a/tests/testit/test-colors.R
+++ b/tests/testit/test-colors.R
@@ -69,17 +69,17 @@ assert(
 
 assert(
   identical(
-    c("#000000", "#7F7F7F", "#FFFFFF"),
+    c("#000000", "#767676", "#FFFFFF"),
     colorNumeric(bw, NULL)(1:3)
   ),
 
   identical(
-    c("#000000", "#7F7F7F", "#FFFFFF"),
+    c("#000000", "#767676", "#FFFFFF"),
     colorNumeric(bw, c(1:3))(1:3)
   ),
 
   identical(
-    rev(c("#000000", "#7F7F7F", "#FFFFFF")),
+    rev(c("#000000", "#767676", "#FFFFFF")),
     colorNumeric(rev(bw), c(1:3))(1:3)
   ),
 
@@ -96,23 +96,23 @@ assert(
 
   # domain == unique(x)
   identical(
-    c("#000000", "#7F7F7F", "#FFFFFF"),
+    c("#000000", "#767676", "#FFFFFF"),
     colorFactor(bw, LETTERS[1:3])(LETTERS[1:3])
   ),
 
   # no domain
   identical(
-    c("#000000", "#7F7F7F", "#FFFFFF"),
+    c("#000000", "#767676", "#FFFFFF"),
     colorFactor(bw, NULL)(LETTERS[1:3])
   ),
 
   # Non-factor domains are sorted unless instructed otherwise
   identical(
-    c("#000000", "#7F7F7F", "#FFFFFF"),
+    c("#000000", "#767676", "#FFFFFF"),
     colorFactor(bw, rev(LETTERS[1:3]))(LETTERS[1:3])
   ),
   identical(
-    rev(c("#000000", "#7F7F7F", "#FFFFFF")),
+    rev(c("#000000", "#767676", "#FFFFFF")),
     colorFactor(bw, rev(LETTERS[1:3]), ordered = TRUE)(LETTERS[1:3])
   ),
 

--- a/tests/testit/test-colors.R
+++ b/tests/testit/test-colors.R
@@ -4,7 +4,7 @@ bw = c("black", "white")
 
 # Do these cases make sense?
 assert(
-  colorBin(bw, NULL)(1) == "#7F7F7F",
+  colorBin(bw, NULL)(1) == "#767676",
   colorBin(bw, 1)(1) == "#FFFFFF",
   TRUE
 )
@@ -90,7 +90,7 @@ assert(
 
   # domain != unique(x)
   identical(
-    c("#000000", "#0A0A0A", "#141414"),
+    c("#000000", "#0E0E0E", "#171717"),
     colorFactor(bw, LETTERS)(LETTERS[1:3])
   ),
 

--- a/tests/testit/test-legend.R
+++ b/tests/testit/test-legend.R
@@ -25,7 +25,7 @@ assert(
 m1 = addLegend(map, pal = pal1, values = ~x1)
 l1 = m1$x$legend
 assert(
-  l1$colors == '#67001F , #67001F 0%, #E58267 25%, #F7F7F7 50%, #6AACD0 75%, #053061 100%, #053061 ',
+  l1$colors == "#66001F , #66001F 0%, #E58366 25%, #F7F7F7 50%, #6DABD0 75%, #053060 100%, #053060 ",
   l1$labels == c('1.0', '1.5', '2.0', '2.5', '3.0'),
   l1$type == 'numeric'
 )
@@ -33,7 +33,7 @@ assert(
 m2 = addLegend(map, pal = pal2, values = ~x2)
 l2 = m2$x$legend
 assert(
-  l2$colors == c('#67001F', '#F7B698', '#A7CFE4', '#053061'),
+  l2$colors == c("#66001F", "#F8B698", "#A7CFE4", "#053060"),
   l2$labels == c('1.0 &ndash; 1.5', '1.5 &ndash; 2.0', '2.0 &ndash; 2.5', '2.5 &ndash; 3.0'),
   l2$type == 'bin'
 )
@@ -41,7 +41,7 @@ assert(
 m3 = addLegend(map, pal = pal3, values = ~x3)
 l3 = m3$x$legend
 assert(
-  l3$colors == c('#F7FCFD', '#AADED2', '#37A265', '#00441B'),
+  l3$colors == c("#F7FCFD", "#AADED2", "#37A265", "#00441A"),
   l3$labels == c(
     '<span title="1.0 &ndash; 1.5">0% &ndash; 25%</span>',
     '<span title="1.5 &ndash; 2.0">25% &ndash; 50%</span>',
@@ -54,7 +54,7 @@ assert(
 m4 = addLegend(map, pal = pal4, values = ~x4)
 l4 = m4$x$legend
 assert(
-  l4$colors == c('#1B9E77', '#A66753', '#666666'),
+  l4$colors == c("#1A9E77", "#B27D5C", "#666666"),
   l4$labels == as.character(df$x4),
   l4$type == 'factor'
 )


### PR DESCRIPTION
Using Lab for color interpolation instead of RGB is recommended by Hadley and http://howaboutanorange.com/blog/2011/08/10/color_interpolation/

Unfortunately, `colorRamp(space = 'Lab')` is much, much slower than `colorRamp(space = 'rgb')`, but I have a fast implementation in rasterfaster that we can switch to once we are ready to take that dependency.