### PR TITLE
Invalidate map size when widget is resized

### DIFF
--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -821,8 +821,8 @@ var dataframe = (function() {
 
       setTimeout(function() { updateBounds(map); }, 1);
     },
-    resize: function(el, width, height, data) {
-
+    resize: function(el, width, height, map) {
+      map.invalidateSize();
     }
   });
 


### PR DESCRIPTION
Without this, then resizes that occur for reasons other
than the overall window being resized will not allow
tile layers to be rendered properly.