### PR TITLE
Remove spurious unbindAll calls

### DIFF
--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -229,14 +229,12 @@ var dataframe = (function() {
   ControlStore.prototype.clear = function() {
     for (var i = 0; i < this._controlsNoId.length; i++) {
       var control = this._controlsNoId[i];
-      Shiny.unbindAll(control._div);
       this._map.removeControl(control);
     };
     this._controlsNoId = [];
 
     for (var key in this._controlsById) {
       var control = this._controlsById[key];
-      Shiny.unbindAll(control._div);
       this._map.removeControl(control)
     }
     this._controlsById = {}


### PR DESCRIPTION
When legends are present, these resolve to Shiny.unbindAll(undefined)
since legends don't have _div fields.

It turns out that controls with _div fields already call Shiny.unbindAll
so there's no need to do it again here anyway.

Fixes #97 "Two updates of legend via inputmap_marker_click$id causes
updates to stop."