### PR TITLE
closes #121: the default title from deparse(values) may be bad

### DIFF
--- a/R/legend.R
+++ b/R/legend.R
@@ -53,7 +53,7 @@
 addLegend = function(
   map, position = c('topright', 'bottomright', 'bottomleft', 'topleft'),
   pal, values, na.label = 'NA', bins = 7, colors, opacity = 0.5, labels,
-  labFormat = labelFormat(), title = deparse(substitute(values)),
+  labFormat = labelFormat(), title = NULL,
   layerId = NULL
 ) {
   position = match.arg(position)

--- a/man/addLegend.Rd
+++ b/man/addLegend.Rd
@@ -6,7 +6,7 @@
 \usage{
 addLegend(map, position = c("topright", "bottomright", "bottomleft", "topleft"), 
     pal, values, na.label = "NA", bins = 7, colors, opacity = 0.5, labels, 
-    labFormat = labelFormat(), title = deparse(substitute(values)), layerId = NULL)
+    labFormat = labelFormat(), title = NULL, layerId = NULL)
 
 labelFormat(prefix = "", suffix = "", between = " &ndash; ", digits = 3, big.mark = ",", 
     transform = identity)


### PR DESCRIPTION
when values is a formula, I think it still makes sense to deparse() the RHS of the formula by default: https://github.com/rstudio/leaflet/blob/0bcdd2d52500ad17043f3973cbd3856df9a09179/R/legend.R#L68