### PR TITLE
add `popupOptions` to layers and markers

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -477,6 +477,7 @@ addMarkers = function(
   map, lng = NULL, lat = NULL, layerId = NULL, group = NULL,
   icon = NULL,
   popup = NULL,
+  popupOptions = NULL,
   label = NULL,
   labelOptions = NULL,
   options = markerOptions(),
@@ -511,8 +512,9 @@ addMarkers = function(
 
   pts = derivePoints(data, lng, lat, missing(lng), missing(lat), "addMarkers")
   invokeMethod(
-    map, data, 'addMarkers', pts$lat, pts$lng, icon, layerId, group, options, popup,
-    clusterOptions, clusterId, safeLabel(label, data), labelOptions
+    map, data, 'addMarkers', pts$lat, pts$lng, icon, layerId, group, options,
+    popup, popupOptions, clusterOptions, clusterId,
+    safeLabel(label, data), labelOptions
   ) %>% expandLimits(pts$lat, pts$lng)
 }
 
@@ -759,6 +761,7 @@ addCircleMarkers = function(
   fillOpacity = 0.2,
   dashArray = NULL,
   popup = NULL,
+  popupOptions = NULL,
   label = NULL,
   labelOptions = NULL,
   options = pathOptions(),
@@ -775,7 +778,8 @@ addCircleMarkers = function(
     map$dependencies = c(map$dependencies, markerClusterDependencies())
   pts = derivePoints(data, lng, lat, missing(lng), missing(lat), "addCircleMarkers")
   invokeMethod(map, data, 'addCircleMarkers', pts$lat, pts$lng, radius,
-      layerId, group, options, clusterOptions, clusterId, popup, safeLabel(label, data), labelOptions) %>%
+               layerId, group, options, clusterOptions, clusterId,
+               popup, popupOptions, safeLabel(label, data), labelOptions) %>%
     expandLimits(pts$lat, pts$lng)
 }
 
@@ -847,6 +851,7 @@ addCircles = function(
   fillOpacity = 0.2,
   dashArray = NULL,
   popup = NULL,
+  popupOptions = NULL,
   label = NULL,
   labelOptions = NULL,
   options = pathOptions(),
@@ -858,7 +863,8 @@ addCircles = function(
     dashArray = dashArray
   ))
   pts = derivePoints(data, lng, lat, missing(lng), missing(lat), "addCircles")
-  invokeMethod(map, data, 'addCircles', pts$lat, pts$lng, radius, layerId, group, options, popup, safeLabel(label, data), labelOptions) %>%
+  invokeMethod(map, data, 'addCircles', pts$lat, pts$lng, radius, layerId, group, options,
+               popup, popupOptions, safeLabel(label, data), labelOptions) %>%
     expandLimits(pts$lat, pts$lng)
 }
 
@@ -880,6 +886,7 @@ addPolylines = function(
   smoothFactor = 1.0,
   noClip = FALSE,
   popup = NULL,
+  popupOptions = NULL,
   label = NULL,
   labelOptions = NULL,
   options = pathOptions(),
@@ -891,7 +898,8 @@ addPolylines = function(
     dashArray = dashArray, smoothFactor = smoothFactor, noClip = noClip
   ))
   pgons = derivePolygons(data, lng, lat, missing(lng), missing(lat), "addPolylines")
-  invokeMethod(map, data, 'addPolylines', pgons, layerId, group, options, popup, safeLabel(label, data), labelOptions) %>%
+  invokeMethod(map, data, 'addPolylines', pgons, layerId, group, options,
+               popup, popupOptions, safeLabel(label, data), labelOptions) %>%
     expandLimitsBbox(pgons)
 }
 
@@ -912,6 +920,7 @@ addRectangles = function(
   smoothFactor = 1.0,
   noClip = FALSE,
   popup = NULL,
+  popupOptions = NULL,
   label = NULL,
   labelOptions = NULL,
   options = pathOptions(),
@@ -926,7 +935,7 @@ addRectangles = function(
   lat1 = resolveFormula(lat1, data)
   lng2 = resolveFormula(lng2, data)
   lat2 = resolveFormula(lat2, data)
-  invokeMethod(map, data, 'addRectangles',lat1, lng1, lat2, lng2, layerId, group, options, popup, safeLabel(label, data), labelOptions) %>%
+  invokeMethod(map, data, 'addRectangles',lat1, lng1, lat2, lng2, layerId, group, options, popup, popupOptions, safeLabel(label, data), labelOptions) %>%
     expandLimits(c(lat1, lat2), c(lng1, lng2))
 }
 
@@ -945,6 +954,7 @@ addPolygons = function(
   smoothFactor = 1.0,
   noClip = FALSE,
   popup = NULL,
+  popupOptions = NULL,
   label = NULL,
   labelOptions = NULL,
   options = pathOptions(),
@@ -956,7 +966,7 @@ addPolygons = function(
     dashArray = dashArray, smoothFactor = smoothFactor, noClip = noClip
   ))
   pgons = derivePolygons(data, lng, lat, missing(lng), missing(lat), "addPolygons")
-  invokeMethod(map, data, 'addPolygons', pgons, layerId, group, options, popup, safeLabel(label, data), labelOptions) %>%
+  invokeMethod(map, data, 'addPolygons', pgons, layerId, group, options, popup, popupOptions, safeLabel(label, data), labelOptions) %>%
     expandLimitsBbox(pgons)
 }
 

--- a/javascript/src/methods.js
+++ b/javascript/src/methods.js
@@ -139,7 +139,14 @@ function addMarkers(map, df, group, clusterOptions, clusterId, markerFunc) {
           this.layerManager.addLayer(marker, "marker", thisId, thisGroup);
         }
         let popup = df.get(i, "popup");
-        if (popup !== null) marker.bindPopup(popup);
+        let popupOptions = df.get(i, 'popupOptions');
+        if (popup !== null) {
+          if (popupOptions !== null){
+            marker.bindPopup(popup, popupOptions);
+          } else {
+            marker.bindPopup(popup);
+          }
+        }
         let label = df.get(i, "label");
         let labelOptions = df.get(i, "labelOptions");
         if (label !== null) {
@@ -165,7 +172,7 @@ function addMarkers(map, df, group, clusterOptions, clusterId, markerFunc) {
   }).call(map);
 }
 
-methods.addMarkers = function(lat, lng, icon, layerId, group, options, popup,
+methods.addMarkers = function(lat, lng, icon, layerId, group, options, popup, popupOptions,
                               clusterOptions, clusterId, label, labelOptions) {
   let icondf;
   let getIcon;
@@ -217,6 +224,7 @@ methods.addMarkers = function(lat, lng, icon, layerId, group, options, popup,
     .col("layerId", layerId)
     .col("group", group)
     .col("popup", popup)
+    .col("popupOptions", popupOptions)
     .col("label", label)
     .col("labelOptions", labelOptions)
     .cbind(options);
@@ -230,7 +238,7 @@ methods.addMarkers = function(lat, lng, icon, layerId, group, options, popup,
   });
 };
 
-methods.addAwesomeMarkers = function(lat, lng, icon, layerId, group, options, popup,
+methods.addAwesomeMarkers = function(lat, lng, icon, layerId, group, options, popup, popupOptions,
 clusterOptions, clusterId, label, labelOptions) {
   let icondf;
   let getIcon;
@@ -257,6 +265,7 @@ clusterOptions, clusterId, label, labelOptions) {
     .col("layerId", layerId)
     .col("group", group)
     .col("popup", popup)
+    .col("popupOptions", popupOptions)
     .col("label", label)
     .col("labelOptions", labelOptions)
     .cbind(options);
@@ -279,7 +288,14 @@ function addLayers(map, category, df, layerFunc) {
       this.layerManager.addLayer(layer, category, thisId, thisGroup);
       if (layer.bindPopup) {
         let popup = df.get(i, "popup");
-        if (popup !== null) layer.bindPopup(popup);
+        let popupOptions = df.get(i, 'popupOptions');
+        if (popup !== null) {
+          if (popupOptions !== null){
+            layer.bindPopup(popup, popupOptions);
+          } else {
+            layer.bindPopup(popup);
+          }
+        }
       }
       if (layer.bindLabel) {
         let label = df.get(i, "label");
@@ -299,7 +315,7 @@ function addLayers(map, category, df, layerFunc) {
   }
 }
 
-methods.addCircles = function(lat, lng, radius, layerId, group, options, popup, label, labelOptions) {
+methods.addCircles = function(lat, lng, radius, layerId, group, options, popup, popupOptions, label, labelOptions) {
   let df = new DataFrame()
     .col("lat", lat)
     .col("lng", lng)
@@ -307,6 +323,7 @@ methods.addCircles = function(lat, lng, radius, layerId, group, options, popup, 
     .col("layerId", layerId)
     .col("group", group)
     .col("popup", popup)
+    .col("popupOptions", popupOptions)
     .col("label", label)
     .col("labelOptions", labelOptions)
     .cbind(options);
@@ -316,7 +333,7 @@ methods.addCircles = function(lat, lng, radius, layerId, group, options, popup, 
   });
 };
 
-methods.addCircleMarkers = function(lat, lng, radius, layerId, group, options, clusterOptions, clusterId, popup, label, labelOptions) {
+methods.addCircleMarkers = function(lat, lng, radius, layerId, group, options, clusterOptions, clusterId, popup, popupOptions, label, labelOptions) {
   let df = new DataFrame()
     .col("lat", lat)
     .col("lng", lng)
@@ -324,6 +341,7 @@ methods.addCircleMarkers = function(lat, lng, radius, layerId, group, options, c
     .col("layerId", layerId)
     .col("group", group)
     .col("popup", popup)
+    .col("popupOptions", popupOptions)
     .col("label", label)
     .col("labelOptions", labelOptions)
     .cbind(options);
@@ -337,12 +355,13 @@ methods.addCircleMarkers = function(lat, lng, radius, layerId, group, options, c
  * @param lat Array of arrays of latitude coordinates for polylines
  * @param lng Array of arrays of longitude coordinates for polylines
  */
-methods.addPolylines = function(polygons, layerId, group, options, popup, label, labelOptions) {
+methods.addPolylines = function(polygons, layerId, group, options, popup, popupOptions, label, labelOptions) {
   let df = new DataFrame()
     .col("shapes", polygons)
     .col("layerId", layerId)
     .col("group", group)
     .col("popup", popup)
+    .col("popupOptions", popupOptions)
     .col("label", label)
     .col("labelOptions", labelOptions)
     .cbind(options);
@@ -384,7 +403,7 @@ methods.clearShapes = function() {
   this.layerManager.clearLayers("shape");
 };
 
-methods.addRectangles = function(lat1, lng1, lat2, lng2, layerId, group, options, popup, label, labelOptions) {
+methods.addRectangles = function(lat1, lng1, lat2, lng2, layerId, group, options, popup, popupOptions, label, labelOptions) {
   let df = new DataFrame()
     .col("lat1", lat1)
     .col("lng1", lng1)
@@ -393,6 +412,7 @@ methods.addRectangles = function(lat1, lng1, lat2, lng2, layerId, group, options
     .col("layerId", layerId)
     .col("group", group)
     .col("popup", popup)
+    .col("popupOptions", popupOptions)
     .col("label", label)
     .col("labelOptions", labelOptions)
     .cbind(options);
@@ -411,12 +431,13 @@ methods.addRectangles = function(lat1, lng1, lat2, lng2, layerId, group, options
  * @param lat Array of arrays of latitude coordinates for polygons
  * @param lng Array of arrays of longitude coordinates for polygons
  */
-methods.addPolygons = function(polygons, layerId, group, options, popup, label, labelOptions) {
+methods.addPolygons = function(polygons, layerId, group, options, popup, popupOptions, label, labelOptions) {
   let df = new DataFrame()
     .col("shapes", polygons)
     .col("layerId", layerId)
     .col("group", group)
     .col("popup", popup)
+    .col("popupOptions", popupOptions)
     .col("label", label)
     .col("labelOptions", labelOptions)
     .cbind(options);


### PR DESCRIPTION
Reported in https://github.com/rstudio/leaflet/issues/258, `popupOptions` were not being supplied as the [optional argument](http://leafletjs.com/reference.html#marker-bindpopup) to `bindPopup` for layers and markers.  This pull adds `popupOptions` to all layers and markers, so 

- `addMarkers`
- `addCircleMarkers`
- `addPolygons`
- `addPolylines`
- `addCircles`
- `addRectangles`
- `addAwesomeMarkers`

Here are examples of the new `popupOptions` in action.

```
# work on adding popupOptions to markers
#  https://github.com/rstudio/leaflet/issues/258

library(leaflet)

pop <- "teeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeest"


# try addMarkers with popupOptions
leaflet() %>% addTiles() %>%
  addMarkers(
    lng = 13.05, lat = 47.8,
    popup = pop,
    popupOptions = popupOptions(maxWidth = 1000, closeOnClick = TRUE)
  )

# try addCircleMarkers with popupOptions
leaflet() %>% addTiles() %>%
  addCircleMarkers(
    lng = 13.05, lat = 47.8,
    popup = pop,
    popupOptions = popupOptions(maxWidth = 1000, closeOnClick = TRUE)
  )

# try addAwesomeMarkers with popupOptions
icon.glyphicon <- makeAwesomeIcon(
  icon= 'flag', markerColor = 'blue',
  iconColor = 'black', library = 'glyphicon'
)
leaflet() %>% addTiles() %>%
  addAwesomeMarkers(
    lng = 13.05, lat = 47.8,
    icon = icon.glyphicon,
    popup = pop,
    popupOptions = popupOptions(maxWidth = 1000, closeOnClick = TRUE)
  )


# try addCircles with popupOptions
cities <- read.csv(textConnection("
City,Lat,Long,Pop
Boston,42.3601,-71.0589,645966
Hartford,41.7627,-72.6743,125017
New York City,40.7127,-74.0059,8406000
Philadelphia,39.9500,-75.1667,1553000
Pittsburgh,40.4397,-79.9764,305841
Providence,41.8236,-71.4222,177994
"))

leaflet(cities) %>% addTiles() %>%
  addCircles(lng = ~Long, lat = ~Lat, weight = 1,
             radius = ~sqrt(Pop) * 30,
             popup = ~paste0(City,Lat,Long,Pop),
             popupOptions = popupOptions(minWidth = 400, closeOnClick = TRUE)
  )

# try addMarkers with popupOptions
leaflet() %>% addTiles() %>%
  addRectangles(
    lng1=-118.456554, lat1=34.078039,
    lng2=-118.436383, lat2=34.062717,
    fillColor = "transparent",
    popup = pop,
    popupOptions = popupOptions(maxWidth = 1000, closeOnClick = TRUE)
  )
```