### PR TITLE
Add npm package dependencies.

### DIFF
--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -1846,7 +1846,6 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 // pixel of the original image has some contribution to the downscaled image)
 // as opposed to a single-step downscaling which will discard a lot of data
 // (and with sparse images at small scales can give very surprising results).
-
 var Mipmapper = function () {
   function Mipmapper(img) {
     _classCallCheck(this, Mipmapper);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "devDependencies": {
     "babel": "^6.5.2",
     "babel-preset-es2015": "^6.6.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.14.0",
+    "babel-register": "^6.14.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.0",
     "eslint": "^2.9.0",


### PR DESCRIPTION
@jcheng5 `grunt build` gives errors due to incomplete npm package dependencies. With the two extra babel modules, build is successful.