### PR TITLE
Don't require leafletProxy(session$ns(mapId))

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -88,7 +88,8 @@ invokeMethod = function(map, data, method, ...) {
 #' execute on the live Leaflet map instance.
 #'
 #' @param mapId single-element character vector indicating the output ID of the
-#'   map to modify
+#'   map to modify (if invoked from a Shiny module, the namespace will be added
+#'   automatically)
 #' @param session the Shiny session object to which the map belongs; usually the
 #'   default value will suffice
 #' @param data a data object; see Details under the \code{\link{leaflet}} help
@@ -130,6 +131,21 @@ leafletProxy <- function(mapId, session = shiny::getDefaultReactiveDomain(),
 
   if (is.null(session)) {
     stop("leafletProxy must be called from the server function of a Shiny app")
+  }
+
+  # If this is a new enough version of Shiny that it supports modules, and
+  # we're in a module (nzchar(session$ns(NULL))), and the mapId doesn't begin
+  # with the current namespace, then add the namespace.
+  #
+  # We could also have unconditionally done `mapId <- session$ns(mapId)`, but
+  # older versions of Leaflet would have broken unless the user did session$ns
+  # themselves, and we hate to break their code unnecessarily.
+  #
+  # This won't be necessary in future versions of Shiny, as session$ns (and
+  # other forms of ns()) will be smart enough to only namespace un-namespaced
+  # IDs.
+  if (!is.null(session$ns) && nzchar(session$ns(NULL)) && !startsWith(mapId, session$ns(""))) {
+    mapId <- session$ns(mapId)
   }
 
   structure(

--- a/man/leafletProxy.Rd
+++ b/man/leafletProxy.Rd
@@ -9,7 +9,8 @@ leafletProxy(mapId, session = shiny::getDefaultReactiveDomain(),
 }
 \arguments{
 \item{mapId}{single-element character vector indicating the output ID of the
-map to modify}
+map to modify (if invoked from a Shiny module, the namespace will be added
+automatically)}
 
 \item{session}{the Shiny session object to which the map belongs; usually the
 default value will suffice}


### PR DESCRIPTION
Fixes #243.

Automatically wrap with session$ns() if necessary, but, don't
if it's already namespaced. This is because existing code might
be doing session$ns(), and we don't want to break them.

Example app showing that both "mapId" and session$ns("mapId")
work:

```
library(shiny)
library(leaflet)

mapUI <- function(id) {
  ns <- NS(id)

  leafletOutput(ns("map"))
}

map <- function(input, output, session) {
  output$map <- renderLeaflet({
    leaflet()
  })

  # leafletProxy is module-aware. It is only necessary to specify the
  # map's unnamespaced outputId, "map".
  leafletProxy("map") %>% addTiles()

  # Using session$ns() to wrap the mapId, is supported for backward
  # compatibility reasons. Newer code should leave it off.
  leafletProxy(session$ns("map")) %>% addMarkers(data = quakes) %>%
    fitBounds(min(quakes$long), min(quakes$lat),
      max(quakes$long), max(quakes$lat))
}

ui <- fluidPage(
  mapUI("one")
)

server <- function(input, output, session) {
  callModule(map, "one")
}

shinyApp(ui, server)
```