### PR TITLE
Fixes rstudio/leaflet#309

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -551,18 +551,19 @@ addLabelOnlyMarkers = function(
   clusterId = NULL,
   data = getMapData(map)
 ) {
-  addMarkers(map = map, lng = lng, lat = lat, layerId = layerId,
-             group = group,
-             icon = makeIcon(iconUrl =
-                               system.file('htmlwidgets/lib/leaflet/images/1px.png',
-                                           package='leaflet'),
-                             iconWidth = 1, iconHeight = 1),
-             label = label,
-             labelOptions = labelOptions,
-             options = options,
-             clusterOptions = clusterOptions,
-             clusterId = clusterId,
-             data = data)
+  do.call(addMarkers, filterNULL(list(
+    map = map, lng = lng, lat = lat, layerId = layerId,
+    group = group,
+    icon = makeIcon(
+      iconUrl = system.file('htmlwidgets/lib/leaflet/images/1px.png', package='leaflet'),
+      iconWidth = 1, iconHeight = 1),
+      label = label,
+      labelOptions = labelOptions,
+      options = options,
+      clusterOptions = clusterOptions,
+      clusterId = clusterId,
+      data = data
+  )))
 }
 
 #' Adds marker-cluster-plugin HTML dependency


### PR DESCRIPTION
A small bug because we check for missing args in addMarkers, so I have to explicitly remove the NULL args in addLabelOnlyMarkers.

Fixes rstudio/leaflet#309