### PR TITLE
plotly crosstalk experiments

### DIFF
--- a/inst/examples/plotly.R
+++ b/inst/examples/plotly.R
@@ -1,0 +1,19 @@
+library(crosstalk)
+library(plotly)
+library(leaflet)
+
+sd <- SharedData$new(quakes)
+
+p <- plot_ly(sd, x = ~depth, y = ~mag) %>%
+  add_markers(alpha = 0.5) %>%
+  layout(dragmode = "select") %>%
+  highlight(dynamic = TRUE, persistent = TRUE)
+
+map <- leaflet(sd) %>%
+  addTiles() %>%
+  addCircles()
+
+# let leaflet know this is persistent selection
+options(persistent = TRUE)
+
+htmltools::browsable(htmltools::tagList(p, map))

--- a/javascript/src/layer-manager.js
+++ b/javascript/src/layer-manager.js
@@ -95,6 +95,9 @@ export default class LayerManager {
         // Need to save this info so we know what to set opacity to later
         layer.options.origOpacity = typeof(layer.options.opacity) !== "undefined" ? layer.options.opacity : 0.5;
         layer.options.origFillOpacity = typeof(layer.options.fillOpacity) !== "undefined" ? layer.options.fillOpacity : 0.2;
+        layer.options.origColor = typeof(layer.options.color) !== "undefined" ? layer.options.color : "#03F";
+        layer.options.origFillColor = typeof(layer.options.fillColor) !== "undefined" ? layer.options.fillColor : layer.options.origColor;
+
       }
 
       let ctg = this._byCrosstalkGroup[ctGroup];
@@ -132,7 +135,12 @@ export default class LayerManager {
             for (let i = 0; i < groupKeys.length; i++) {
               let key = groupKeys[i];
               let layerInfo = this._byStamp[ctg[key]];
-              this._setOpacity(layerInfo, 1.0);
+              // reset the crosstalk style params
+              layerInfo.layer.options.ctOpacity = undefined;
+              layerInfo.layer.options.ctFillOpacity = undefined;
+              layerInfo.layer.options.ctColor = undefined;
+              layerInfo.layer.options.ctFillColor = undefined;
+              this._setStyle(layerInfo);
             }
           } else {
             let selectedKeys = {};
@@ -140,10 +148,31 @@ export default class LayerManager {
               selectedKeys[e.value[i]] = true;
             }
             let groupKeys = Object.keys(ctg);
+            // for compatability with plotly's ability to colour selections
+            // https://github.com/jcheng5/plotly/blob/71cf8a/R/crosstalk.R#L96-L100
+            let selectionColour = crosstalk.var("plotlySelectionColour").get();
+            let ctOpts = crosstalk.var("plotlyCrosstalkOpts").get() || {opacityDim: 0.2};
+            let persist = ctOpts.persistent === true;
             for (let i = 0; i < groupKeys.length; i++) {
               let key = groupKeys[i];
               let layerInfo = this._byStamp[ctg[key]];
-              this._setOpacity(layerInfo, selectedKeys[groupKeys[i]] ? 1.0 : 0.2);
+              let selected = selectedKeys[groupKeys[i]];
+              let opts = layerInfo.layer.options;
+
+              // remember "old" selection colors if this is persistent selection
+              layerInfo.layer.options.ctColor =
+                selected ? selectionColour :
+                  persist ? opts.ctColor : opts.origColor;
+              layerInfo.layer.options.ctFillColor =
+                selected ? selectionColour :
+                  persist ? opts.ctFillColor : opts.origFillColor;
+
+              layerInfo.layer.options.ctOpacity =
+                  selected ? opts.origOpacity :
+                    (persist && opts.origOpacity == opts.ctOpacity) ? opts.origOpacity :
+                      ctOpts.opacityDim * opts.origOpacity;
+
+              this._setStyle(layerInfo);
             }
           }
         };
@@ -214,15 +243,17 @@ export default class LayerManager {
     }
   }
 
-  _setOpacity(layerInfo, opacity) {
-    if (layerInfo.layer.setOpacity) {
-      layerInfo.layer.setOpacity(opacity);
-    } else if (layerInfo.layer.setStyle) {
-      layerInfo.layer.setStyle({
-        opacity: opacity * layerInfo.layer.options.origOpacity,
-        fillOpacity: opacity * layerInfo.layer.options.origFillOpacity
-      });
+  _setStyle(layerInfo) {
+    let opts = layerInfo.layer.options;
+    if (!layerInfo.layer.setStyle) {
+      return;
     }
+    layerInfo.layer.setStyle({
+      opacity: opts.ctOpacity || opts.origOpacity,
+      fillOpacity: opts.ctFillOpacity || opts.origFillOpacity,
+      color: opts.ctColor || opts.origColor,
+      fillColor: opts.ctFillColor || opts.origFillColor
+    });
   }
 
   getLayer(category, layerId) {


### PR DESCRIPTION
This continues work from #281. The idea is to have leaflet respond to plotly's "advanced" crosstalk selection options (e.g., [dynamically altering selection colour and persistent selection](https://cpsievert.github.io/plotly_book/images/plotlyLeaflet.gif))

I'd still consider this PR "experimental" as [I'm hoping to add more selection modes (e.g., AND, OR, XOR, COMPLEMENT)](https://github.com/ropensci/plotly/issues/836). I hope to iron out those details before Feb.

