### PR TITLE
Fix typo in addMarkers documentation

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -492,7 +492,7 @@ labelOptions <- function(
 #'    you can use \code{\link{markerClusterOptions}()} to specify marker cluster
 #'   options
 #' @param clusterId the id for the marker cluster layer
-#' @describeIn map-layers Add markders to the map
+#' @describeIn map-layers Add markers to the map
 #' @export
 addMarkers <- function(
   map, lng = NULL, lat = NULL, layerId = NULL, group = NULL,

--- a/man/map-layers.Rd
+++ b/man/map-layers.Rd
@@ -228,7 +228,7 @@ Options to highlight shapes (polylines/polygons/circles/rectangles)
 
 \item \code{safeLabel}: Create a label with sanitized text/html
 
-\item \code{addMarkers}: Add markders to the map
+\item \code{addMarkers}: Add markers to the map
 
 \item \code{addLabelOnlyMarkers}: Add Label only markers to the map
 


### PR DESCRIPTION
Fixing a simple typo ("markders") in the addMarkers documentation.