### PR TITLE
support MULTIPOLYGON by ruthless flattening

### DIFF
--- a/R/normalize-sf.R
+++ b/R/normalize-sf.R
@@ -23,6 +23,10 @@ pointData.sfc_POINT <- function(obj) {
   )
 }
 
+#' @export
+pointData.sfc_MULTIPOINT <- pointData.sfc_POINT
+
+
 # polygonData -------------------------------------------------------------
 
 #' @export

--- a/R/normalize-sf.R
+++ b/R/normalize-sf.R
@@ -44,13 +44,8 @@ polygonData.sfc <- function(obj) {
 #' @export
 polygonData.MULTIPOLYGON <- function(obj) {
   n <- vapply(obj, length, integer(1))
-  if (any(n > 1L)) {
-    warning(
-      "leaflet currently does not support MULTIPOLYGONS. Taking first",
-      call. = FALSE)
-  }
 
-  lapply(obj, function(x) sf_coords(x[[1]]))
+  unlist(lapply(obj, function(x) lapply(x, sf_coords)), recursive = FALSE)
 }
 #' @export
 polygonData.MULTILINESTRING <- polygonData.MULTIPOLYGON


### PR DESCRIPTION
This pull request adds support for MULTIPOLYGON, by downgrading the extra structure in the `sf` object to one analogous to that used by `sp` (and shapefiles).  I.e. rings that are holes in other rings are stored in one flat collection, ambiguously about which hole belongs where. This works for vis. though because the polygon rendering just uses the evenodd rule. 

It's a problem for round-tripping, but then on the `sf` side it's not going to be hard to calculate which ring belongs in which island. I thought it should be discussed at least, but very happy to see this supported now, thanks!  


Basic example, from the sf1 vignette: 

```R
## multipolygon
library(sf)
p1 <- rbind(c(0,0), c(1,0), c(3,2), c(2,4), c(1,4), c(0,0))
p2 <- rbind(c(1,1), c(1,2), c(2,2), c(1,1))
pol <-st_polygon(list(p1,p2))
p3 <- rbind(c(3,0), c(4,0), c(4,1), c(3,1), c(3,0))
p4 <- rbind(c(3.3,0.3), c(3.8,0.3), c(3.8,0.8), c(3.3,0.8), c(3.3,0.3))[5:1,]
p5 <- rbind(c(3,3), c(4,2), c(4,3), c(3,3))
(mpol <- st_multipolygon(list(list(p1,p2), list(p3,p4), list(p5))))

mp <- st_sfc(mpol, crs = "+proj=merc +datum=WGS84")
library(leaflet)
leaflet() %>% leaflet::addPolygons(data = mp)

```

Here are two real-world data sets with different map projections, and interestingly different situations of multipolygons, multiple features, and holes. 

There's code here to download two GeoPackage files (850Kb and 1.4Mb), transform them to angular coordinates on the WGS84 datum, and plot.  I include a subsetting, because Lake Superior proper has holes in it, that are filled by other features.  

```R
library(leaflet)
library(sf)
## a couple of realer examples 850KB and 1.4Mb 
uf <- c("https://github.com/r-gris/polyggon/raw/master/inst/extdata/water_lake_superior_basin.gpkg", 
        "https://github.com/r-gris/polyggon/raw/master/inst/extdata/inlandwaters.gpkg")
td <- tempdir()
for (i in seq_along(uf)) download.file(uf[i], file.path(td, basename(uf[i])), mode = "wb")

## read the layers from the GeoPackage (it's a SQLite db, understood by GDAL)
lake_superior <- st_read(file.path(td, basename(uf[1])), layer = "lake_superior_basin")
lakey <- st_read(file.path(td, basename(uf[2])), layer = "inlandwaters")

## reproject to longlat :|
lake_superior_ll <- st_transform(lake_superior, "+proj=longlat +datum=WGS84")
lakey_ll <- st_transform(lakey, "+proj=longlat +datum=WGS84")

## Lake Superior
## 
## the holes have other features in them :)
leaflet() %>%  addPolygons(data = lake_superior_ll)
## this is the lake, which isn't a hole, but has holes in it, and there are islands in the holes :0
idx <- which.max(st_area(lake_superior))
leaflet() %>%  addPolygons(data = lake_superior_ll[idx, ])

## Inland waters, Australia
##
## these multipolygons with holes also work fine: 
leaflet() %>%  addTiles() %>% addPolygons(data = lakey_ll)
```