### PR TITLE
Color function improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ BugReports: https://github.com/rstudio/leaflet/issues
 Depends: R (>= 3.1.0)
 Imports:
     base64enc,
+    crosstalk,
     htmlwidgets,
     htmltools,
     magrittr,
@@ -44,7 +45,7 @@ Imports:
     raster,
     scales (>= 0.2.5),
     sp,
-    crosstalk
+    viridis
 Suggests:
     knitr,
     maps,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,6 +45,7 @@ Imports:
     raster,
     scales (>= 0.2.5),
     sp,
+    stats,
     viridis
 Suggests:
     knitr,

--- a/NEWS
+++ b/NEWS
@@ -25,7 +25,11 @@ leaflet 1.1
 
 * Upgrade leaflet.js to 0.7.7.1 (PR #359)
 
-* Color palette functions now support viridis palettes ("viridis", "magma", "inferno", and "plasma").
+* Color palette improvements. All color palette functions now support viridis palettes ("viridis", "magma", "inferno", and "plasma").
+
+* Color palette functions now support reversing the order in which colors are used, via reverse=TRUE.
+
+* colorFactor no longer interpolates qualitative RColorBrewer palettes, unless the number of factor levels being mapped exceeds the number of colors in the specified RColorBrewer palette. (Issue #300)
 
 leaflet 1.0.2
 --------------------------------------------------------------------------------

--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,8 @@ leaflet 1.1
 
 * Upgrade leaflet.js to 0.7.7.1 (PR #359)
 
+* Color palette functions now support viridis palettes ("viridis", "magma", "inferno", and "plasma").
+
 leaflet 1.0.2
 --------------------------------------------------------------------------------
 

--- a/R/colors.R
+++ b/R/colors.R
@@ -301,7 +301,7 @@ toPaletteFunc <- function(pal, alpha, nlevels) {
 }
 
 # Strings are interpreted as color names, unless length is 1 and it's the name
-# of an RColorBrewer palette
+# of an RColorBrewer palette that is marked as qualitative
 toPaletteFunc.character <- function(pal, alpha, nlevels) {
   if (length(pal) == 1 && pal %in% row.names(RColorBrewer::brewer.pal.info)) {
     paletteInfo <- RColorBrewer::brewer.pal.info[pal,]
@@ -316,18 +316,13 @@ toPaletteFunc.character <- function(pal, alpha, nlevels) {
         }
       }
     }
-
-    return(scales::colour_ramp(colors, alpha = alpha))
+  } else if (length(pal) == 1 && pal %in% c("viridis", "magma", "inferno", "plasma")) {
+    colors <- viridis::viridis(n = 256, option = pal)
+  } else {
+    colors <- pal
   }
 
-  if (length(pal) == 1 && pal %in% c("viridis", "magma", "inferno", "plasma")) {
-    return(scales::colour_ramp(
-      viridis::viridis(n = 256, alpha = 1, option = pal),
-      alpha = alpha
-    ))
-  }
-
-  scales::colour_ramp(pal, alpha = alpha)
+  scales::colour_ramp(colors, alpha = alpha)
 }
 
 # Accept colorRamp style matrix

--- a/R/colors.R
+++ b/R/colors.R
@@ -296,10 +296,17 @@ toPaletteFunc <- function(pal, alpha, nlevels) {
   UseMethod("toPaletteFunc")
 }
 
+# Wrapper function for brewer.pal that deals with n < 3, plus returns maxcolors
+# by default
 brewer_pal <- function(palette, n = NULL) {
   if (is.null(n))
     n <- RColorBrewer::brewer.pal.info[palette, "maxcolors"]
 
+  # Work around the fact that if brewer.pal is passed a number smaller than 3,
+  # it returns 3 colors anyway with a warning.
+  #
+  # It also warns if passed a number greater than maxcolors, but that's OK, we
+  # want the user to see that warning.
   colors <- RColorBrewer::brewer.pal(max(3, n), palette)
   if (n == 1) {
     colors[1]

--- a/R/colors.R
+++ b/R/colors.R
@@ -23,6 +23,10 @@
 #' @param alpha Whether alpha channels should be respected or ignored. If
 #'   \code{TRUE} then colors without explicit alpha information will be treated
 #'   as fully opaque.
+#' @param reverse Whether the colors (or color function) in \code{palette}
+#'   should be used in reverse order. For example, if the default order of a
+#'   palette goes from blue to green, then \code{reverse = TRUE} will result in
+#'   the colors going from green to blue.
 #'
 #' @return A function that takes a single parameter \code{x}; when called with a
 #'   vector of numbers (except for \code{colorFactor}, which expects
@@ -30,7 +34,7 @@
 #'   \code{alpha=TRUE} in which case #RRGGBBAA may also be possible).
 #'
 #' @export
-colorNumeric <- function(palette, domain, na.color = "#808080", alpha = FALSE) {
+colorNumeric <- function(palette, domain, na.color = "#808080", alpha = FALSE, reverse = FALSE) {
   rng = NULL
   if (length(domain) > 0) {
     rng = range(domain, na.rm = TRUE)
@@ -51,6 +55,10 @@ colorNumeric <- function(palette, domain, na.color = "#808080", alpha = FALSE) {
     rescaled = scales::rescale(x, from = rng)
     if (any(rescaled < 0 | rescaled > 1, na.rm = TRUE))
       warning("Some values were outside the color scale and will be treated as NA")
+
+    if (reverse) {
+      rescaled <- 1 - rescaled
+    }
     pf(rescaled)
   })
 }
@@ -98,7 +106,7 @@ getBins <- function(domain, x, bins, pretty) {
 #' @rdname colorNumeric
 #' @export
 colorBin <- function(palette, domain, bins = 7, pretty = TRUE,
-  na.color = "#808080", alpha = FALSE) {
+  na.color = "#808080", alpha = FALSE, reverse = FALSE) {
 
   # domain usually needs to be explicitly provided (even if NULL) but not if
   # breaks are specified
@@ -109,7 +117,8 @@ colorBin <- function(palette, domain, bins = 7, pretty = TRUE,
   if (!is.null(domain))
     bins = getBins(domain, NULL, bins, pretty)
   numColors = if (length(bins) == 1) bins else length(bins) - 1
-  colorFunc = colorFactor(palette, domain = if (!autobin) 1:numColors, na.color = na.color)
+  colorFunc = colorFactor(palette, domain = if (!autobin) 1:numColors,
+    na.color = na.color, alpha = alpha, reverse = reverse)
   pf = safePaletteFunc(palette, na.color, alpha)
 
   withColorAttr('bin', list(bins = bins, na.color = na.color), function(x) {
@@ -133,14 +142,15 @@ colorBin <- function(palette, domain, bins = 7, pretty = TRUE,
 #' @rdname colorNumeric
 #' @export
 colorQuantile <- function(palette, domain, n = 4,
-  probs = seq(0, 1, length.out = n + 1), na.color = "#808080", alpha = FALSE) {
+  probs = seq(0, 1, length.out = n + 1), na.color = "#808080", alpha = FALSE,
+  reverse = FALSE) {
 
   if (!is.null(domain)) {
     bins = quantile(domain, probs, na.rm = TRUE, names = FALSE)
     return(withColorAttr(
       'quantile', list(probs = probs, na.color = na.color),
       colorBin(palette, domain = NULL, bins = bins, na.color = na.color,
-        alpha = alpha)
+        alpha = alpha, reverse = reverse)
     ))
   }
 
@@ -148,7 +158,7 @@ colorQuantile <- function(palette, domain, n = 4,
   # If you say probs = seq(0, 1, 0.25), which has length 5, does that map to 4 colors
   # or 5? 4, right?
   colorFunc = colorFactor(palette, domain = 1:(length(probs) - 1),
-    na.color = na.color, alpha = alpha)
+    na.color = na.color, alpha = alpha, reverse = reverse)
 
   withColorAttr('quantile', list(probs = probs, na.color = na.color), function(x) {
     binsToUse = quantile(x, probs, na.rm = TRUE, names = FALSE)
@@ -165,7 +175,7 @@ calcLevels <- function(x, ordered) {
   if (is.null(x)) {
     NULL
   } else if (is.factor(x)) {
-    levels(x)
+    as.character(levels(x))
   } else if (ordered) {
     unique(x)
   } else {
@@ -175,7 +185,7 @@ calcLevels <- function(x, ordered) {
 
 getLevels <- function(domain, x, lvls, ordered) {
   if (!is.null(lvls))
-    return(lvls)
+    return(as.character(lvls))
 
   if (!is.null(domain)) {
     return(calcLevels(domain, ordered))
@@ -196,7 +206,7 @@ getLevels <- function(domain, x, lvls, ordered) {
 #' @rdname colorNumeric
 #' @export
 colorFactor <- function(palette, domain, levels = NULL, ordered = FALSE,
-  na.color = "#808080", alpha = FALSE) {
+  na.color = "#808080", alpha = FALSE, reverse = FALSE) {
 
   # domain usually needs to be explicitly provided (even if NULL) but not if
   # levels are specified
@@ -210,29 +220,30 @@ colorFactor <- function(palette, domain, levels = NULL, ordered = FALSE,
   }
   lvls = getLevels(domain, NULL, levels, ordered)
   hasFixedLevels = is.null(lvls)
-  pf = safePaletteFunc(palette, na.color, alpha)
 
   withColorAttr('factor', list(na.color = na.color), function(x) {
     if (length(x) == 0 || all(is.na(x))) {
-      return(pf(x))
+      return(rep.int(na.color, length(x)))
     }
 
     lvls = getLevels(domain, x, lvls, ordered)
+    pf = safePaletteFunc(palette, na.color, alpha, nlevels = length(lvls) * ifelse(reverse, -1, 1))
 
-    if (!is.factor(x) || hasFixedLevels) {
-      origNa = is.na(x)
-      # Seems like we need to re-factor if hasFixedLevels, in case the x value
-      # has a different set of levels (like if droplevels was called in between
-      # when the domain was given and now)
-      x = factor(x, lvls)
-      if (any(is.na(x) != origNa)) {
-        warning("Some values were outside the color scale and will be treated as NA")
-      }
+    origNa = is.na(x)
+    # Seems like we need to re-factor if hasFixedLevels, in case the x value
+    # has a different set of levels (like if droplevels was called in between
+    # when the domain was given and now)
+    x = factor(x, lvls)
+    if (any(is.na(x) != origNa)) {
+      warning("Some values were outside the color scale and will be treated as NA")
     }
 
     scaled = scales::rescale(as.integer(x), from = c(1, length(lvls)))
     if (any(scaled < 0 | scaled > 1, na.rm = TRUE)) {
       warning("Some values were outside the color scale and will be treated as NA")
+    }
+    if (reverse) {
+      scaled <- 1 - scaled
     }
     pf(scaled)
   })
@@ -269,23 +280,44 @@ colorFactor <- function(palette, domain, levels = NULL, ordered = FALSE,
 NULL
 
 
-safePaletteFunc <- function(pal, na.color, alpha) {
-  toPaletteFunc(pal, alpha=alpha) %>% filterRGB() %>% filterZeroLength() %>%
-    filterNA(na.color) %>% filterRange()
+safePaletteFunc <- function(pal, na.color, alpha, nlevels = NULL) {
+  toPaletteFunc(pal, alpha=alpha, nlevels = nlevels) %>%
+    filterRGB() %>%
+    filterZeroLength() %>%
+    filterNA(na.color) %>%
+    filterRange()
 }
 
-toPaletteFunc <- function(pal, alpha) {
+# nlevels is a positive or negative integer (or integral number) indicating the
+# number of levels to use for a discrete scale (i.e. factor, i.e. qualitative,
+# i.e. categorical); or NULL if it is a continuous scale. A negative value means
+# that the user has asked for a "reversed" palette, so pull from the tail of the
+# color palette rather than from the head.
+#
+# (Previous versions of this code didn't have nlevels and simply interpolated
+# between colors in a qualitative palette--clearly the wrong thing to do.)
+toPaletteFunc <- function(pal, alpha, nlevels) {
   UseMethod("toPaletteFunc")
 }
 
 # Strings are interpreted as color names, unless length is 1 and it's the name
 # of an RColorBrewer palette
-toPaletteFunc.character <- function(pal, alpha) {
+toPaletteFunc.character <- function(pal, alpha, nlevels) {
   if (length(pal) == 1 && pal %in% row.names(RColorBrewer::brewer.pal.info)) {
-    return(scales::colour_ramp(
-      RColorBrewer::brewer.pal(RColorBrewer::brewer.pal.info[pal, 'maxcolors'], pal),
-      alpha = alpha
-    ))
+    paletteInfo <- RColorBrewer::brewer.pal.info[pal,]
+    colors <- RColorBrewer::brewer.pal(paletteInfo$maxcolors, pal)
+
+    if (!is.null(nlevels) && paletteInfo$category == "qual") {
+      if (abs(nlevels) < paletteInfo$maxcolors) {
+        if (nlevels < 0) {
+          colors <- tail(colors, -nlevels)
+        } else {
+          colors <- head(colors, nlevels)
+        }
+      }
+    }
+
+    return(scales::colour_ramp(colors, alpha = alpha))
   }
 
   if (length(pal) == 1 && pal %in% c("viridis", "magma", "inferno", "plasma")) {
@@ -299,12 +331,12 @@ toPaletteFunc.character <- function(pal, alpha) {
 }
 
 # Accept colorRamp style matrix
-toPaletteFunc.matrix <- function(pal, alpha) {
+toPaletteFunc.matrix <- function(pal, alpha, nlevels) {
   toPaletteFunc(rgb(pal, maxColorValue = 255), alpha = alpha)
 }
 
 # If a function, just assume it's already a function over [0-1]
-toPaletteFunc.function <- function(pal, alpha) {
+toPaletteFunc.function <- function(pal, alpha, nlevels) {
   pal
 }
 

--- a/R/colors.R
+++ b/R/colors.R
@@ -242,6 +242,7 @@ colorFactor <- function(palette, domain, levels = NULL, ordered = FALSE,
 #' \enumerate{
 #'   \item{A character vector of RGB or named colors. Examples: \code{palette()}, \code{c("#000000", "#0000FF", "#FFFFFF")}, \code{topo.colors(10)}}
 #'   \item{The name of an RColorBrewer palette, e.g. \code{"BuPu"} or \code{"Greens"}.}
+#'   \item{The full name of a viridis palette: \code{"viridis"}, \code{"magma"}, \code{"inferno"}, or \code{"plasma"}.}
 #'   \item{A function that receives a single value between 0 and 1 and returns a color. Examples: \code{colorRamp(c("#000000", "#FFFFFF"), interpolate="spline")}.}
 #' }
 #' @examples
@@ -283,6 +284,13 @@ toPaletteFunc.character <- function(pal, alpha) {
   if (length(pal) == 1 && pal %in% row.names(RColorBrewer::brewer.pal.info)) {
     return(scales::colour_ramp(
       RColorBrewer::brewer.pal(RColorBrewer::brewer.pal.info[pal, 'maxcolors'], pal),
+      alpha = alpha
+    ))
+  }
+
+  if (length(pal) == 1 && pal %in% c("viridis", "magma", "inferno", "plasma")) {
+    return(scales::colour_ramp(
+      viridis::viridis(n = 256, alpha = 1, option = pal),
       alpha = alpha
     ))
   }

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -146,7 +146,7 @@ polygonData.matrix <- function(obj) {
   ))
 
   # Split into polygons wherever there is a row of NA
-  missing <- !complete.cases(df)
+  missing <- !stats::complete.cases(df)
   group <- cumsum(missing)
   polys <- split(df[!missing, , drop = FALSE], group[!missing])
 

--- a/man/colorNumeric.Rd
+++ b/man/colorNumeric.Rd
@@ -7,16 +7,17 @@
 \alias{colorQuantile}
 \title{Color mapping}
 \usage{
-colorNumeric(palette, domain, na.color = "#808080", alpha = FALSE)
+colorNumeric(palette, domain, na.color = "#808080", alpha = FALSE,
+  reverse = FALSE)
 
 colorBin(palette, domain, bins = 7, pretty = TRUE, na.color = "#808080",
-  alpha = FALSE)
+  alpha = FALSE, reverse = FALSE)
 
 colorQuantile(palette, domain, n = 4, probs = seq(0, 1, length.out = n + 1),
-  na.color = "#808080", alpha = FALSE)
+  na.color = "#808080", alpha = FALSE, reverse = FALSE)
 
 colorFactor(palette, domain, levels = NULL, ordered = FALSE,
-  na.color = "#808080", alpha = FALSE)
+  na.color = "#808080", alpha = FALSE, reverse = FALSE)
 }
 \arguments{
 \item{palette}{The colors or color function that values will be mapped to}
@@ -39,6 +40,11 @@ colorFactor(palette, domain, levels = NULL, ordered = FALSE,
 \item{alpha}{Whether alpha channels should be respected or ignored. If
 \code{TRUE} then colors without explicit alpha information will be treated
 as fully opaque.}
+
+\item{reverse}{Whether the colors (or color function) in \code{palette}
+should be used in reverse order. For example, if the default order of a
+palette goes from blue to green, then \code{reverse = TRUE} will result in
+the colors going from green to blue.}
 
 \item{bins}{Either a numeric vector of two or more unique cut points or a
 single number (greater than or equal to 2) giving the number of intervals

--- a/man/colorNumeric.Rd
+++ b/man/colorNumeric.Rd
@@ -90,6 +90,7 @@ The \code{palette} argument can be any of the following:
 \enumerate{
   \item{A character vector of RGB or named colors. Examples: \code{palette()}, \code{c("#000000", "#0000FF", "#FFFFFF")}, \code{topo.colors(10)}}
   \item{The name of an RColorBrewer palette, e.g. \code{"BuPu"} or \code{"Greens"}.}
+  \item{The full name of a viridis palette: \code{"viridis"}, \code{"magma"}, \code{"inferno"}, or \code{"plasma"}.}
   \item{A function that receives a single value between 0 and 1 and returns a color. Examples: \code{colorRamp(c("#000000", "#FFFFFF"), interpolate="spline")}.}
 }
 }

--- a/tests/testit/test-legend.R
+++ b/tests/testit/test-legend.R
@@ -58,7 +58,7 @@ assert(
 m4 = addLegend(map, pal = pal4, values = ~x4)
 l4 = getLastLegend(m4)
 assert(
-  l4$colors == c("#1B9E77", "#B27D5D", "#666666"),
+  l4$colors == c("#1B9E77", "#D95F02", "#7570B3"),
   l4$labels == as.character(df$x4),
   l4$type == 'factor'
 )

--- a/tests/testit/test-legend.R
+++ b/tests/testit/test-legend.R
@@ -37,7 +37,7 @@ assert(
 m2 = addLegend(map, pal = pal2, values = ~x2)
 l2 = getLastLegend(m2)
 assert(
-  l2$colors == c("#67001F", "#F8B799", "#A8D0E4", "#053061"),
+  l2$colors == c("#CA0020", "#F4A582", "#92C5DE", "#0571B0"),
   l2$labels == c('1.0 &ndash; 1.5', '1.5 &ndash; 2.0', '2.0 &ndash; 2.5', '2.5 &ndash; 3.0'),
   l2$type == 'bin'
 )
@@ -45,7 +45,7 @@ assert(
 m3 = addLegend(map, pal = pal3, values = ~x3)
 l3 = getLastLegend(m3)
 assert(
-  l3$colors == c("#F7FCFD", "#AADFD3", "#38A265", "#00441B"),
+  l3$colors == c("#EDF8FB", "#B2E2E2", "#66C2A4", "#238B45"),
   l3$labels == c(
     '<span title="1.0 &ndash; 1.5">0% &ndash; 25%</span>',
     '<span title="1.5 &ndash; 2.0">25% &ndash; 50%</span>',

--- a/tests/testthat/test-colors.R
+++ b/tests/testthat/test-colors.R
@@ -1,0 +1,118 @@
+context("colors")
+
+test_that("factors match by name, not position", {
+
+  full <- factor(letters[1:5])
+  pal <- colorFactor("magma", na.color = NA, levels = full)
+
+  partial <- full[2:4]
+  expect_identical(pal(partial), pal(droplevels(partial)))
+
+  # Sending in values outside of the color scale should result in a warning and na.color
+  expect_warning(pal(letters[10:20]))
+  expect_true(suppressWarnings(all(is.na(pal(letters[10:20])))))
+})
+
+test_that("qualitative palettes don't interpolate", {
+  pal <- colorFactor("Accent", na.color = NA, levels = letters[1:5])
+
+  allColors <- RColorBrewer::brewer.pal(
+    n = RColorBrewer::brewer.pal.info["Accent","maxcolors"],
+    name = "Accent")
+
+  # If we're not interpolating, then the colors for each level should match
+  # exactly with the color in the corresponding position in the palette.
+  expect_identical(pal(letters[1:5]), allColors[1:5])
+
+  # Same behavior when domain is provided initially
+  expect_identical(
+    colorFactor("Accent", domain = rep(letters[1:5], 2))(letters[1:5]),
+    allColors[1:5]
+  )
+  # Same behavior when domain is provided initially, and is a factor
+  expect_identical(
+    colorFactor("Accent", domain = factor(rep(letters[5:1], 2)))(letters[1:5]),
+    allColors[1:5]
+  )
+  # Same behavior when domain is provided initially, and is not a factor
+  expect_identical(
+    colorFactor("Accent", domain = rep(letters[5:1], 2), ordered = TRUE)(letters[5:1]),
+    allColors[1:5]
+  )
+  # Same behavior when no domain or level is provided initially
+  expect_identical(
+    colorFactor("Accent", NULL)(letters[1:5]),
+    allColors[1:5]
+  )
+
+  # Values outside of the originally provided levels should be NA with warning
+  expect_warning(pal(letters[6]))
+  expect_true(suppressWarnings(is.na(pal(letters[6]))))
+})
+
+test_that("OK, qualitative palettes sometimes interpolate", {
+  pal <- colorFactor("Accent", na.color = NA, levels = letters[1:20])
+
+  allColors <- RColorBrewer::brewer.pal(
+    n = RColorBrewer::brewer.pal.info["Accent","maxcolors"],
+    name = "Accent")
+
+  result <- pal(letters[1:20])
+  # The first and last levels are the first and last palette colors
+  expect_true(all(result[c(1,20)] %in% allColors))
+  # All the rest are interpolated though
+  expect_true(!any(result[-c(1,20)] %in% allColors))
+})
+
+verifyReversal <- function(colorFunc, values, ..., filter = identity) {
+  f1 <- colorFunc("Blues", domain = values, ...)(values)
+  f2 <- colorFunc("Blues", domain = NULL, ...)(values)
+  f3 <- colorFunc("Blues", domain = values, reverse = FALSE, ...)(values)
+  f4 <- colorFunc("Blues", domain = NULL, reverse = FALSE, ...)(values)
+  r1 <- colorFunc("Blues", domain = values, reverse = TRUE, ...)(values)
+  r2 <- colorFunc("Blues", domain = NULL, reverse = TRUE, ...)(values)
+
+  f1 <- filter(f1)
+  f2 <- filter(f2)
+  f3 <- filter(f3)
+  f4 <- filter(f4)
+  r1 <- filter(r1)
+  r2 <- filter(r2)
+
+  expect_identical(f1, f2)
+  expect_identical(f1, f3)
+  expect_identical(f1, f4)
+  expect_identical(r1, r2)
+  expect_identical(f1, rev(r1))
+}
+
+test_that("colorNumeric can be reversed", {
+  verifyReversal(colorNumeric, 1:10)
+})
+
+test_that("colorBin can be reversed", {
+  # colorBin needs to filter because with 10 values and 7 bins, there is some
+  # repetition that occurs in the results. Hard to explain but easy to see:
+  # scales::show_col(colorBin("Blues", NULL)(1:8))
+  # scales::show_col(colorBin("Blues", NULL, reverse = TRUE)(1:8))
+
+  verifyReversal(colorBin, 1:10, filter = unique)
+})
+
+test_that("colorQuantile can be reversed", {
+  verifyReversal(colorQuantile, 1:10, n = 7)
+})
+
+test_that("colorFactor can be reversed", {
+  # With interpolation
+  verifyReversal(colorFactor, letters)
+
+  # Without interpolation
+  accent <- suppressWarnings(RColorBrewer::brewer.pal(Inf, "Accent"))
+  result1 <- colorFactor("Accent", NULL)(letters[1:5])
+  expect_identical(result1, head(accent, 5))
+  # Reversing a qualitative palette means we should pull from the end,
+  # in reverse order
+  result2 <- colorFactor("Accent", NULL, reverse = TRUE)(letters[1:5])
+  expect_identical(result2, rev(tail(accent, 5)))
+})


### PR DESCRIPTION
This PR includes three significant quality-of-life improvements for users of the color palette functions: `colorNumeric`, `colorBin`, `colorQuantile`, and `colorFactor`.

### Native support for viridis palettes

E.g.: `pal <- colorNumeric("magma", values)`. Valid names are `"magma"`, `"inferno"`, `"plasma"`, and `"viridis"`.

### Allow reversing the color scale

E.g. `colorNumeric("magma", values, reverse=TRUE)`. So if your palette runs red-yellow-blue but you want the lower numbers to correspond to the blue end, not the red end, you can now just `reverse=TRUE` instead of retrieving the palette colors and reversing them manually.

### Fix #300: Don't interpolate qualitative palettes

When using qualitative RColorBrewer palettes with factors (or `colorBin` or `colorQuantile`), don't interpolate if possible (factor levels <= number of available colors). This is definitely the right behavior for `colorFactor`, I'm not positive whether it's the right behavior for `colorBin` and `colorQuantile`.