### PR TITLE
addPolygons() now responds to crosstalk events

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -1087,8 +1087,11 @@ addPolygons <- function(
     dashArray = dashArray, smoothFactor = smoothFactor, noClip = noClip
   ))
   pgons = derivePolygons(data, lng, lat, missing(lng), missing(lat), "addPolygons")
-  invokeMethod(map, data, 'addPolygons', pgons, layerId, group, options, popup, popupOptions, safeLabel(label, data), labelOptions, highlightOptions) %>%
-    expandLimitsBbox(pgons)
+  invokeMethod(
+    map, data, 'addPolygons', pgons, layerId, group, options, popup,
+    popupOptions, safeLabel(label, data), labelOptions, highlightOptions,
+    getCrosstalkOptions(data)
+  ) %>% expandLimitsBbox(pgons)
 }
 
 #' @rdname remove

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -1596,9 +1596,9 @@ methods.addRectangles = function (lat1, lng1, lat2, lng2, layerId, group, option
  * @param lat Array of arrays of latitude coordinates for polygons
  * @param lng Array of arrays of longitude coordinates for polygons
  */
-methods.addPolygons = function (polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions) {
+methods.addPolygons = function (polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions, crosstalkOptions) {
   if (polygons.length > 0) {
-    var df = new _dataframe2.default().col("shapes", polygons).col("layerId", layerId).col("group", group).col("popup", popup).col("popupOptions", popupOptions).col("label", label).col("labelOptions", labelOptions).col("highlightOptions", highlightOptions).cbind(options);
+    var df = new _dataframe2.default().col("shapes", polygons).col("layerId", layerId).col("group", group).col("popup", popup).col("popupOptions", popupOptions).col("label", label).col("labelOptions", labelOptions).col("highlightOptions", highlightOptions).cbind(options).cbind(crosstalkOptions || {});
 
     addLayers(this, "shape", df, function (df, i) {
       // This code used to use L.multiPolygon, but that caused
@@ -2296,7 +2296,6 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 // pixel of the original image has some contribution to the downscaled image)
 // as opposed to a single-step downscaling which will discard a lot of data
 // (and with sparse images at small scales can give very surprising results).
-
 var Mipmapper = function () {
   function Mipmapper(img) {
     _classCallCheck(this, Mipmapper);

--- a/javascript/src/methods.js
+++ b/javascript/src/methods.js
@@ -521,7 +521,7 @@ methods.addRectangles = function(lat1, lng1, lat2, lng2, layerId, group, options
  * @param lat Array of arrays of latitude coordinates for polygons
  * @param lng Array of arrays of longitude coordinates for polygons
  */
-methods.addPolygons = function(polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions) {
+methods.addPolygons = function(polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions, crosstalkOptions) {
   if(polygons.length>0) {
     let df = new DataFrame()
       .col("shapes", polygons)
@@ -532,7 +532,8 @@ methods.addPolygons = function(polygons, layerId, group, options, popup, popupOp
       .col("label", label)
       .col("labelOptions", labelOptions)
       .col("highlightOptions", highlightOptions)
-      .cbind(options);
+      .cbind(options)
+      .cbind(crosstalkOptions || {});
 
     addLayers(this, "shape", df, function(df, i) {
       // This code used to use L.multiPolygon, but that caused


### PR DESCRIPTION
For example,

```r
library(crosstalk)
library(sf)
library(plotly)

nc <- st_read(system.file("shape/nc.shp", package="sf")) %>% 
  st_transform(4326)

shared_nc <- nc %>% SharedData$new()

bscols(leaflet(data = shared_nc) %>%
         addTiles() %>%
         addPolygons(opacity = 1,
                     color = 'white',
                     weight = .25,
                     fillOpacity = .5,
                     fillColor = 'blue',
                     smoothFactor = 0),
       plot_ly(shared_nc, x = ~BIR74, y=  ~SID79, type = 'scatter', mode = 'markers')       
)
```

![leaf](https://cloud.githubusercontent.com/assets/1365941/23383696/4a060ab2-fd0d-11e6-818d-11f56950e2c1.gif)

TODO:

  - [ ] Implement `addPolylines()` etc?
  - [ ] Should 2D brush events on polygons emit a crosstalk event?
