### PR TITLE
Hardcode scheme for default OSM tiles

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -116,7 +116,7 @@ hideGroup <- function(map, group) {
 #' @export
 addTiles <- function(
   map,
-  urlTemplate = '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+  urlTemplate = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   attribution = NULL,
   layerId = NULL,
   group = NULL,

--- a/man/map-layers.Rd
+++ b/man/map-layers.Rd
@@ -21,7 +21,8 @@ addControl(map, html, position = c("topleft", "topright", "bottomleft",
   "bottomright"), layerId = NULL, className = "info legend",
   data = getMapData(map))
 
-addTiles(map, urlTemplate = "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+addTiles(map,
+  urlTemplate = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
   attribution = NULL, layerId = NULL, group = NULL,
   options = tileOptions())
 


### PR DESCRIPTION
The "//" relative scheme doesn't work for web pages that are
served from the filesystem.

Fixes #386 