### PR TITLE
Add support for drag event

### DIFF
--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -1325,6 +1325,7 @@ function addMarkers(map, df, group, clusterOptions, clusterId, markerFunc) {
           marker.on("click", mouseHandler(this.id, thisId, thisGroup, "marker_click", extraInfo), this);
           marker.on("mouseover", mouseHandler(this.id, thisId, thisGroup, "marker_mouseover", extraInfo), this);
           marker.on("mouseout", mouseHandler(this.id, thisId, thisGroup, "marker_mouseout", extraInfo), this);
+          marker.on("dragend", mouseHandler(this.id, thisId, thisGroup, "marker_dragend", extraInfo), this);
         }).call(_this3);
       }
     };

--- a/javascript/src/methods.js
+++ b/javascript/src/methods.js
@@ -177,6 +177,7 @@ function addMarkers(map, df, group, clusterOptions, clusterId, markerFunc) {
           marker.on("click", mouseHandler(this.id, thisId, thisGroup, "marker_click", extraInfo), this);
           marker.on("mouseover", mouseHandler(this.id, thisId, thisGroup, "marker_mouseover", extraInfo), this);
           marker.on("mouseout", mouseHandler(this.id, thisId, thisGroup, "marker_mouseout", extraInfo), this);
+          marker.on("dragend", mouseHandler(this.id, thisId, thisGroup, "marker_dragend", extraInfo), this);
         }).call(this);
       }
     }


### PR DESCRIPTION
shiny now receives notification after a marker is dragged, with marker id and new lat-lon.