### PR TITLE
Fixed handling non-finite values in colorBin arg domain.

### DIFF
--- a/R/colors.R
+++ b/R/colors.R
@@ -112,6 +112,8 @@ colorBin <- function(palette, domain, bins = 7, pretty = TRUE,
   # breaks are specified
   if (missing(domain) && length(bins) > 1) {
     domain = NULL
+  } else if (!(length(domain) == 2 && all(is.finite(domain)))) {
+    stop ("'Domain' must be of length 2 and contain finite values only!")
   }
   autobin = is.null(domain) && length(bins) == 1
   if (!is.null(domain))


### PR DESCRIPTION
After investigating the special snowflake error message: "Error in if (bins < 2) { : argument is of length zero", it turned out that colorBin does not check for non-finite values in its 'domain' argument.
