### PR TITLE
Fix typos in docs

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -478,7 +478,7 @@ clearPopups <- function(map) {
 #'
 #' @param label A vector or list of plain characters or HTML (marked by
 #'   \code{\link[htmltools]{HTML}}), or a formula that resolves to such a value.
-#' @param data A data frame over which the formua is evaluated.
+#' @param data A data frame over which the formula is evaluated.
 #'
 #' @keywords internal
 #' @export
@@ -727,7 +727,7 @@ makeIcon <- function(iconUrl = NULL, iconRetinaUrl = NULL, iconWidth = NULL, ico
 #' @param iconWidth,iconHeight size of the icon image in pixels
 #' @param iconAnchorX,iconAnchorY the coordinates of the "tip" of the icon
 #'   (relative to its top left corner, i.e. the top left corner means
-#'   \code{iconAnchorX = 0} and \code{iconAnchorY = 0)}, and the icon will be
+#'   \code{iconAnchorX = 0} and \code{iconAnchorY = 0}), and the icon will be
 #'   aligned so that this point is at the marker's geographical location
 #' @param shadowUrl the URL or file path to the icon shadow image
 #' @param shadowRetinaUrl the URL or file path to the retina sized version of

--- a/R/plugin-awesomeMarkers.R
+++ b/R/plugin-awesomeMarkers.R
@@ -175,7 +175,7 @@ makeAwesomeIcon <- function(
 #'   = 'fa'})
 #' @param extraClasses Additional css classes to include on the icon.
 #' @return A list of awesome-icon data that can be passed to the \code{icon}
-#' @param squareMarker Whether to use a sqare marker.
+#' @param squareMarker Whether to use a square marker.
 #' @param iconRotate Rotate the icon by a given angle.
 #' @param fontFamily Used when \code{text} option is specified.
 #' @param text Use this text string instead of an icon.

--- a/R/plugin-measure.R
+++ b/R/plugin-measure.R
@@ -26,7 +26,7 @@ leafletMeasureDependencies <- function() {
 #' @param completedColor base color to use for features generated
 #'           from a completed measurement.
 #'           Value should be a color represented as a hexadecimal string.
-#' @param popupOptions \code{list} of ptions applied to the popup
+#' @param popupOptions \code{list} of options applied to the popup
 #'           of the resulting measure feature.
 #'           Properties may be any \href{http://leafletjs.com/reference.html#popup-options}{standard Leaflet popup options}.
 #' @param captureZIndex Z-index of the marker used to capture measure clicks.

--- a/man/addLegend.Rd
+++ b/man/addLegend.Rd
@@ -141,3 +141,4 @@ leaflet(df) \%>\%
   ),  group='circles', position='bottomleft' ) \%>\%
   addLayersControl(overlayGroups = c('circles'))
 }
+

--- a/man/addMeasure.Rd
+++ b/man/addMeasure.Rd
@@ -33,7 +33,7 @@ Value should be a color represented as a hexadecimal string.}
 from a completed measurement.
 Value should be a color represented as a hexadecimal string.}
 
-\item{popupOptions}{\code{list} of ptions applied to the popup
+\item{popupOptions}{\code{list} of options applied to the popup
 of the resulting measure feature.
 Properties may be any \href{http://leafletjs.com/reference.html#popup-options}{standard Leaflet popup options}.}
 

--- a/man/awesomeIcons.Rd
+++ b/man/awesomeIcons.Rd
@@ -29,7 +29,7 @@ color (hex, rgba, etc.) or a named web color.}
 
 \item{extraClasses}{Additional css classes to include on the icon.}
 
-\item{squareMarker}{Whether to use a sqare marker.}
+\item{squareMarker}{Whether to use a square marker.}
 
 \item{iconRotate}{Rotate the icon by a given angle.}
 

--- a/man/icons.Rd
+++ b/man/icons.Rd
@@ -20,7 +20,7 @@ icon image}
 
 \item{iconAnchorX, iconAnchorY}{the coordinates of the "tip" of the icon
 (relative to its top left corner, i.e. the top left corner means
-\code{iconAnchorX = 0} and \code{iconAnchorY = 0)}, and the icon will be
+\code{iconAnchorX = 0} and \code{iconAnchorY = 0}), and the icon will be
 aligned so that this point is at the marker's geographical location}
 
 \item{shadowUrl}{the URL or file path to the icon shadow image}

--- a/man/makeAwesomeIcon.Rd
+++ b/man/makeAwesomeIcon.Rd
@@ -28,7 +28,7 @@ color (hex, rgba, etc.) or a named web color.}
 
 \item{extraClasses}{Additional css classes to include on the icon.}
 
-\item{squareMarker}{Whether to use a sqare marker.}
+\item{squareMarker}{Whether to use a square marker.}
 
 \item{iconRotate}{Rotate the icon by a given angle.}
 

--- a/man/makeIcon.Rd
+++ b/man/makeIcon.Rd
@@ -22,12 +22,12 @@ icon image}
 
 \item{iconAnchorX}{the coordinates of the "tip" of the icon
 (relative to its top left corner, i.e. the top left corner means
-\code{iconAnchorX = 0} and \code{iconAnchorY = 0)}, and the icon will be
+\code{iconAnchorX = 0} and \code{iconAnchorY = 0}), and the icon will be
 aligned so that this point is at the marker's geographical location}
 
 \item{iconAnchorY}{the coordinates of the "tip" of the icon
 (relative to its top left corner, i.e. the top left corner means
-\code{iconAnchorX = 0} and \code{iconAnchorY = 0)}, and the icon will be
+\code{iconAnchorX = 0} and \code{iconAnchorY = 0}), and the icon will be
 aligned so that this point is at the marker's geographical location}
 
 \item{shadowUrl}{the URL or file path to the icon shadow image}

--- a/man/safeLabel.Rd
+++ b/man/safeLabel.Rd
@@ -10,7 +10,7 @@ safeLabel(label, data)
 \item{label}{A vector or list of plain characters or HTML (marked by
 \code{\link[htmltools]{HTML}}), or a formula that resolves to such a value.}
 
-\item{data}{A data frame over which the formua is evaluated.}
+\item{data}{A data frame over which the formula is evaluated.}
 }
 \description{
 This is a helper function used internally to HTML-escape user-provided


### PR DESCRIPTION
This PR addresses a few small typos in documentation. The mis-placed `)` in the documentation for `icons` was causing an `R CMD check` note when using `#' @inheritDotParams leaflet::addPolygons` in other packages.