### PR TITLE
Add crosstalk support to addPolygons, addPolylines, addRectangles

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@
 ^package\.json$
 ^node_modules$
 ^data-raw$
+^npm-shrinkwrap\.json$

--- a/R/layers.R
+++ b/R/layers.R
@@ -1048,7 +1048,8 @@ addPolylines <- function(
   ))
   pgons = derivePolygons(data, lng, lat, missing(lng), missing(lat), "addPolylines")
   invokeMethod(map, data, 'addPolylines', pgons, layerId, group, options,
-               popup, popupOptions, safeLabel(label, data), labelOptions, highlightOptions) %>%
+               popup, popupOptions, safeLabel(label, data), labelOptions, highlightOptions,
+               getCrosstalkOptions(data)) %>%
     expandLimitsBbox(pgons)
 }
 
@@ -1089,7 +1090,8 @@ addRectangles <- function(
   df1 <- validateCoords(lng1, lat1, "addRectangles")
   df2 <- validateCoords(lng2, lat2, "addRectangles")
 
-  invokeMethod(map, data, 'addRectangles',df1$lat, df1$lng, df2$lat, df2$lng, layerId, group, options, popup, popupOptions, safeLabel(label, data), labelOptions, highlightOptions) %>%
+  invokeMethod(map, data, 'addRectangles',df1$lat, df1$lng, df2$lat, df2$lng, layerId, group, options, popup, popupOptions, safeLabel(label, data), labelOptions, highlightOptions,
+               getCrosstalkOptions(data)) %>%
     expandLimits(c(lat1, lat2), c(lng1, lng2))
 }
 
@@ -1121,7 +1123,8 @@ addPolygons <- function(
     dashArray = dashArray, smoothFactor = smoothFactor, noClip = noClip
   ))
   pgons = derivePolygons(data, lng, lat, missing(lng), missing(lat), "addPolygons")
-  invokeMethod(map, data, 'addPolygons', pgons, layerId, group, options, popup, popupOptions, safeLabel(label, data), labelOptions, highlightOptions, getCrosstalkOptions(data)) %>%
+  invokeMethod(map, data, 'addPolygons', pgons, layerId, group, options, popup, popupOptions, safeLabel(label, data), labelOptions, highlightOptions,
+               getCrosstalkOptions(data)) %>%
     expandLimitsBbox(pgons)
 }
 

--- a/R/layers.R
+++ b/R/layers.R
@@ -1121,7 +1121,7 @@ addPolygons <- function(
     dashArray = dashArray, smoothFactor = smoothFactor, noClip = noClip
   ))
   pgons = derivePolygons(data, lng, lat, missing(lng), missing(lat), "addPolygons")
-  invokeMethod(map, data, 'addPolygons', pgons, layerId, group, options, popup, popupOptions, safeLabel(label, data), labelOptions, highlightOptions) %>%
+  invokeMethod(map, data, 'addPolygons', pgons, layerId, group, options, popup, popupOptions, safeLabel(label, data), labelOptions, highlightOptions, getCrosstalkOptions(data)) %>%
     expandLimitsBbox(pgons)
 }
 

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -1550,9 +1550,9 @@ methods.addCircleMarkers = function (lat, lng, radius, layerId, group, options, 
  * @param lat Array of arrays of latitude coordinates for polylines
  * @param lng Array of arrays of longitude coordinates for polylines
  */
-methods.addPolylines = function (polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions) {
+methods.addPolylines = function (polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions, crosstalkOptions) {
   if (polygons.length > 0) {
-    var df = new _dataframe2.default().col("shapes", polygons).col("layerId", layerId).col("group", group).col("popup", popup).col("popupOptions", popupOptions).col("label", label).col("labelOptions", labelOptions).col("highlightOptions", highlightOptions).cbind(options);
+    var df = new _dataframe2.default().col("shapes", polygons).col("layerId", layerId).col("group", group).col("popup", popup).col("popupOptions", popupOptions).col("label", label).col("labelOptions", labelOptions).col("highlightOptions", highlightOptions).cbind(options).cbind(crosstalkOptions || {});
 
     addLayers(this, "shape", df, function (df, i) {
       var shapes = df.get(i, "shapes");
@@ -1598,8 +1598,8 @@ methods.clearShapes = function () {
   this.layerManager.clearLayers("shape");
 };
 
-methods.addRectangles = function (lat1, lng1, lat2, lng2, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions) {
-  var df = new _dataframe2.default().col("lat1", lat1).col("lng1", lng1).col("lat2", lat2).col("lng2", lng2).col("layerId", layerId).col("group", group).col("popup", popup).col("popupOptions", popupOptions).col("label", label).col("labelOptions", labelOptions).col("highlightOptions", highlightOptions).cbind(options);
+methods.addRectangles = function (lat1, lng1, lat2, lng2, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions, crosstalkOptions) {
+  var df = new _dataframe2.default().col("lat1", lat1).col("lng1", lng1).col("lat2", lat2).col("lng2", lng2).col("layerId", layerId).col("group", group).col("popup", popup).col("popupOptions", popupOptions).col("label", label).col("labelOptions", labelOptions).col("highlightOptions", highlightOptions).cbind(options).cbind(crosstalkOptions || {});
 
   addLayers(this, "shape", df, function (df, i) {
     if (_jquery2.default.isNumeric(df.get(i, "lat1")) && _jquery2.default.isNumeric(df.get(i, "lng1")) && _jquery2.default.isNumeric(df.get(i, "lat2")) && _jquery2.default.isNumeric(df.get(i, "lng2"))) {

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -1614,9 +1614,9 @@ methods.addRectangles = function (lat1, lng1, lat2, lng2, layerId, group, option
  * @param lat Array of arrays of latitude coordinates for polygons
  * @param lng Array of arrays of longitude coordinates for polygons
  */
-methods.addPolygons = function (polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions) {
+methods.addPolygons = function (polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions, crosstalkOptions) {
   if (polygons.length > 0) {
-    var df = new _dataframe2.default().col("shapes", polygons).col("layerId", layerId).col("group", group).col("popup", popup).col("popupOptions", popupOptions).col("label", label).col("labelOptions", labelOptions).col("highlightOptions", highlightOptions).cbind(options);
+    var df = new _dataframe2.default().col("shapes", polygons).col("layerId", layerId).col("group", group).col("popup", popup).col("popupOptions", popupOptions).col("label", label).col("labelOptions", labelOptions).col("highlightOptions", highlightOptions).cbind(options).cbind(crosstalkOptions || {});
 
     addLayers(this, "shape", df, function (df, i) {
       // This code used to use L.multiPolygon, but that caused

--- a/javascript/src/methods.js
+++ b/javascript/src/methods.js
@@ -432,7 +432,7 @@ methods.addCircleMarkers = function(lat, lng, radius, layerId, group, options, c
  * @param lat Array of arrays of latitude coordinates for polylines
  * @param lng Array of arrays of longitude coordinates for polylines
  */
-methods.addPolylines = function(polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions) {
+methods.addPolylines = function(polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions, crosstalkOptions) {
   if(polygons.length>0) {
     let df = new DataFrame()
       .col("shapes", polygons)
@@ -443,7 +443,8 @@ methods.addPolylines = function(polygons, layerId, group, options, popup, popupO
       .col("label", label)
       .col("labelOptions", labelOptions)
       .col("highlightOptions", highlightOptions)
-      .cbind(options);
+      .cbind(options)
+      .cbind(crosstalkOptions || {});
 
     addLayers(this, "shape", df, function(df, i) {
       let shapes = df.get(i, "shapes");
@@ -487,7 +488,7 @@ methods.clearShapes = function() {
   this.layerManager.clearLayers("shape");
 };
 
-methods.addRectangles = function(lat1, lng1, lat2, lng2, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions) {
+methods.addRectangles = function(lat1, lng1, lat2, lng2, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions, crosstalkOptions) {
   let df = new DataFrame()
     .col("lat1", lat1)
     .col("lng1", lng1)
@@ -499,8 +500,9 @@ methods.addRectangles = function(lat1, lng1, lat2, lng2, layerId, group, options
     .col("popupOptions", popupOptions)
     .col("label", label)
     .col("labelOptions", labelOptions)
-      .col("highlightOptions", highlightOptions)
-    .cbind(options);
+    .col("highlightOptions", highlightOptions)
+    .cbind(options)
+    .cbind(crosstalkOptions || {});
 
   addLayers(this, "shape", df, function(df, i) {
     if($.isNumeric(df.get(i, "lat1")) && $.isNumeric(df.get(i, "lng1")) &&

--- a/javascript/src/methods.js
+++ b/javascript/src/methods.js
@@ -521,7 +521,7 @@ methods.addRectangles = function(lat1, lng1, lat2, lng2, layerId, group, options
  * @param lat Array of arrays of latitude coordinates for polygons
  * @param lng Array of arrays of longitude coordinates for polygons
  */
-methods.addPolygons = function(polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions) {
+methods.addPolygons = function(polygons, layerId, group, options, popup, popupOptions, label, labelOptions, highlightOptions, crosstalkOptions) {
   if(polygons.length>0) {
     let df = new DataFrame()
       .col("shapes", polygons)
@@ -532,7 +532,8 @@ methods.addPolygons = function(polygons, layerId, group, options, popup, popupOp
       .col("label", label)
       .col("labelOptions", labelOptions)
       .col("highlightOptions", highlightOptions)
-      .cbind(options);
+      .cbind(options)
+      .cbind(crosstalkOptions || {});
 
     addLayers(this, "shape", df, function(df, i) {
       // This code used to use L.multiPolygon, but that caused

--- a/tests/testit/test-remote.R
+++ b/tests/testit/test-remote.R
@@ -150,7 +150,7 @@ assert(
   identical(mockSession$.calls, list())
 )
 mockSession$.flush()
-expected <- list(structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addPolygons\",\"args\":[[[[{\"lng\":[1,2,3,4,5],\"lat\":[1,2,3,4,5]}]]],null,null,{\"lineCap\":null,\"lineJoin\":null,\"clickable\":true,\"pointerEvents\":null,\"className\":\"\",\"stroke\":true,\"color\":\"#03F\",\"weight\":5,\"opacity\":0.5,\"fill\":true,\"fillColor\":\"#03F\",\"fillOpacity\":0.2,\"dashArray\":null,\"smoothFactor\":1,\"noClip\":false},null,null,null,null,null]}]}", class = "json")), .Names = c("type",
+expected <- list(structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addPolygons\",\"args\":[[[[{\"lng\":[1,2,3,4,5],\"lat\":[1,2,3,4,5]}]]],null,null,{\"lineCap\":null,\"lineJoin\":null,\"clickable\":true,\"pointerEvents\":null,\"className\":\"\",\"stroke\":true,\"color\":\"#03F\",\"weight\":5,\"opacity\":0.5,\"fill\":true,\"fillColor\":\"#03F\",\"fillOpacity\":0.2,\"dashArray\":null,\"smoothFactor\":1,\"noClip\":false},null,null,null,null,null,null]}]}", class = "json")), .Names = c("type",
   "message")))
 dput(mockSession$.calls)
 assert(identical(mockSession$.calls, expected))


### PR DESCRIPTION
As discussed in https://github.com/rstudio/crosstalk/issues/47, the master branch of `leaflet` and the one on CRAN don't support `crosstalk` in all layers.  This patch adds crosstalk support to `addPolygons`, `addPolylines`, `addRectangles`.