### PR TITLE
Add options parameter to fitBounds

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -35,6 +35,8 @@ setView <- function(map, lng, lat, zoom, options = list()) {
 
 #' @describeIn map-methods Set the bounds of a map
 #' @param lng1,lat1,lng2,lat2 the coordinates of the map bounds
+#' @param options a list of zoom/pan options (see
+#'   \url{http://leafletjs.com/reference.html#zoom/pan-options})
 #' @export
 fitBounds <- function(map, lng1, lat1, lng2, lat2, options = list()) {
   bounds = evalFormula(list(lat1, lng1, lat2, lng2, options), getMapData(map))

--- a/R/methods.R
+++ b/R/methods.R
@@ -36,8 +36,8 @@ setView <- function(map, lng, lat, zoom, options = list()) {
 #' @describeIn map-methods Set the bounds of a map
 #' @param lng1,lat1,lng2,lat2 the coordinates of the map bounds
 #' @export
-fitBounds <- function(map, lng1, lat1, lng2, lat2) {
-  bounds = evalFormula(list(lat1, lng1, lat2, lng2), getMapData(map))
+fitBounds <- function(map, lng1, lat1, lng2, lat2, options = list()) {
+  bounds = evalFormula(list(lat1, lng1, lat2, lng2, options), getMapData(map))
 
   dispatch(map,
     "fitBounds",

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -1205,8 +1205,8 @@ methods.setView = function (center, zoom, options) {
   this.setView(center, zoom, options);
 };
 
-methods.fitBounds = function (lat1, lng1, lat2, lng2) {
-  this.fitBounds([[lat1, lng1], [lat2, lng2]]);
+methods.fitBounds = function (lat1, lng1, lat2, lng2, options) {
+  this.fitBounds([[lat1, lng1], [lat2, lng2]], options);
 };
 
 methods.setMaxBounds = function (lat1, lng1, lat2, lng2) {

--- a/javascript/src/methods.js
+++ b/javascript/src/methods.js
@@ -44,10 +44,10 @@ methods.setView = function(center, zoom, options) {
   this.setView(center, zoom, options);
 };
 
-methods.fitBounds = function(lat1, lng1, lat2, lng2) {
+methods.fitBounds = function(lat1, lng1, lat2, lng2, options) {
   this.fitBounds([
     [lat1, lng1], [lat2, lng2]
-  ]);
+  ], options);
 };
 
 methods.setMaxBounds = function(lat1, lng1, lat2, lng2) {

--- a/man/map-methods.Rd
+++ b/man/map-methods.Rd
@@ -9,7 +9,7 @@
 \usage{
 setView(map, lng, lat, zoom, options = list())
 
-fitBounds(map, lng1, lat1, lng2, lat2)
+fitBounds(map, lng1, lat1, lng2, lat2, options = list())
 
 setMaxBounds(map, lng1, lat1, lng2, lat2)
 


### PR DESCRIPTION
The fitBounds method in leaflet.js allows, like many other methods, to pass an options object. The R interface didn't have that possibility. After the change, it is possible to call for example.

```R
leaflet() %>% fitBounds(1, 1, 2, 2, options = list(animate=TRUE))
```

Wasn't sure if the bindings code in ```/inst/legacy/www/leaflet.js ``` should be changed, however...