### PR TITLE
add tileOptions() to addRasterImage()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -49,6 +49,8 @@ leaflet 2.0.0
 
 * Added `method` argument to `addRasterImage()` to enable nearest neighbor interpolation when projecting categorical rasters (#462)
 
+* Added `options` argument to `addRasterImage()` to give finer control over the added tile. (#507)
+
 * Added an `'auto'` method for `addRasterImage()`. Projected factor results are coerced into factors. (9accc7e)
 
 * Added `data` parameter to remaining `addXXX()` methods, including addLegend. (f273edd, #491, #485)

--- a/R/layers.R
+++ b/R/layers.R
@@ -202,8 +202,6 @@ epsg3857 <- "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y
 #' @param colors the color palette (see \code{\link{colorNumeric}}) or function
 #'   to use to color the raster values (hint: if providing a function, set
 #'   \code{na.color} to \code{"#00000000"} to make \code{NA} areas transparent)
-#' @param opacity the base opacity of the raster, expressed from 0 to 1
-#' @param attribution the HTML string to show as the attribution for this layer
 #' @param layerId the layer id
 #' @param group the name of the group this raster image should belong to (see
 #'   the same parameter under \code{\link{addTiles}})
@@ -218,6 +216,9 @@ epsg3857 <- "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y
 #'   Ignored if \code{project = FALSE}. See \code{\link{projectRaster}} for details.
 #' @param maxBytes the maximum number of bytes to allow for the projected image
 #'   (before base64 encoding); defaults to 4MB.
+#' @param options a list of extra options for tile layers, popups, paths
+#'   (circles, rectangles, polygons, ...), or other map elements
+#' @seealso \code{\link{tileOptions}}
 #' @template data-getMapData
 #'
 #' @examples
@@ -234,13 +235,12 @@ addRasterImage <- function(
   map,
   x,
   colors = if (raster::is.factor(x)) "Set1" else "Spectral",
-  opacity = 1,
-  attribution = NULL,
   layerId = NULL,
   group = NULL,
   project = TRUE,
   method = c("auto", "bilinear", "ngb"),
   maxBytes = 4 * 1024 * 1024,
+  options = tileOptions(),
   data = getMapData(map)
 ) {
   stopifnot(inherits(x, "RasterLayer"))
@@ -302,7 +302,10 @@ addRasterImage <- function(
     list(raster::ymin(bounds), raster::xmax(bounds))
   )
 
-  invokeMethod(map, data, "addRasterImage", uri, latlng, opacity, attribution, layerId, group) %>%
+  options$detectRetina = TRUE
+  options$async = TRUE
+
+  invokeMethod(map, data, "addRasterImage", uri, latlng, layerId, group, options) %>%
     expandLimits(
       c(raster::ymin(bounds), raster::ymax(bounds)),
       c(raster::xmin(bounds), raster::xmax(bounds))

--- a/R/layers.R
+++ b/R/layers.R
@@ -203,9 +203,9 @@ epsg3857 <- "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y
 #'   to use to color the raster values (hint: if providing a function, set
 #'   \code{na.color} to \code{"#00000000"} to make \code{NA} areas transparent)
 #' @param opacity the base opacity of the raster, expressed from 0 to 1
-#'   (if set will overwrite \code{options})
+#'   (deprecated, if set will overwrite \code{options})
 #' @param attribution the HTML string to show as the attribution for this layer
-#'   (can be also passed via \code{options})
+#'   (deprecated, if set will overwrite \code{options})
 #' @param layerId the layer id
 #' @param group the name of the group this raster image should belong to (see
 #'   the same parameter under \code{\link{addTiles}})
@@ -310,12 +310,16 @@ addRasterImage <- function(
 
   options$detectRetina = TRUE
   options$async = TRUE
-  # if attribution not passed via options
-  if (!exists('attribution', where = options))
+  # if attribution is set
+  if (!missing(attribution)) {
+    warning("argument 'attribution' is deprecated. Use options= instead.")
     options$attribution <- attribution
+  }
   # if opacity is set
-  if (!is.null(opacity))
+  if (!missing(opacity)) {
+    warning("argument 'opacity' is deprecated. Use options= instead.")
     options$opacity <- opacity
+  }
 
   invokeMethod(map, data, "addRasterImage", uri, latlng, layerId, group, options) %>%
     expandLimits(

--- a/R/layers.R
+++ b/R/layers.R
@@ -202,6 +202,10 @@ epsg3857 <- "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y
 #' @param colors the color palette (see \code{\link{colorNumeric}}) or function
 #'   to use to color the raster values (hint: if providing a function, set
 #'   \code{na.color} to \code{"#00000000"} to make \code{NA} areas transparent)
+#' @param opacity the base opacity of the raster, expressed from 0 to 1
+#'   (if set will overwrite \code{options})
+#' @param attribution the HTML string to show as the attribution for this layer
+#'   (can be also passed via \code{options})
 #' @param layerId the layer id
 #' @param group the name of the group this raster image should belong to (see
 #'   the same parameter under \code{\link{addTiles}})
@@ -235,6 +239,8 @@ addRasterImage <- function(
   map,
   x,
   colors = if (raster::is.factor(x)) "Set1" else "Spectral",
+  opacity = NULL,
+  attribution = NULL,
   layerId = NULL,
   group = NULL,
   project = TRUE,
@@ -304,6 +310,12 @@ addRasterImage <- function(
 
   options$detectRetina = TRUE
   options$async = TRUE
+  # if attribution not passed via options
+  if (!exists('attribution', where = options))
+    options$attribution <- attribution
+  # if opacity is set
+  if (!is.null(opacity))
+    options$opacity <- opacity
 
   invokeMethod(map, data, "addRasterImage", uri, latlng, layerId, group, options) %>%
     expandLimits(

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -2063,7 +2063,7 @@ methods.setGroupOptions = function (group, options) {
   this.showHideGroupsOnZoom();
 };
 
-methods.addRasterImage = function (uri, bounds, opacity, attribution, layerId, group) {
+methods.addRasterImage = function (uri, bounds, layerId, group, options) {
   // uri is a data URI containing an image. We want to paint this image as a
   // layer at (top-left) bounds[0] to (bottom-right) bounds[1].
 
@@ -2182,12 +2182,7 @@ methods.addRasterImage = function (uri, bounds, opacity, attribution, layerId, g
   };
   img.src = uri;
 
-  var canvasTiles = _leaflet2.default.gridLayer({
-    opacity: opacity,
-    attribution: attribution,
-    detectRetina: true,
-    async: true
-  });
+  var canvasTiles = _leaflet2.default.gridLayer(options);
 
   // NOTE: The done() function MUST NOT be invoked until after the current
   // tick; done() looks in Leaflet's tile cache for the current tile, and

--- a/javascript/src/methods.js
+++ b/javascript/src/methods.js
@@ -969,7 +969,7 @@ methods.setGroupOptions = function(group, options) {
   this.showHideGroupsOnZoom();
 };
 
-methods.addRasterImage = function(uri, bounds, opacity, attribution, layerId, group) {
+methods.addRasterImage = function(uri, bounds, layerId, group, options) {
   // uri is a data URI containing an image. We want to paint this image as a
   // layer at (top-left) bounds[0] to (bottom-right) bounds[1].
 
@@ -1090,12 +1090,7 @@ methods.addRasterImage = function(uri, bounds, opacity, attribution, layerId, gr
   };
   img.src = uri;
 
-  let canvasTiles = L.gridLayer({
-    opacity: opacity,
-    attribution: attribution,
-    detectRetina: true,
-    async: true
-  });
+  let canvasTiles = L.gridLayer(options);
 
   // NOTE: The done() function MUST NOT be invoked until after the current
   // tick; done() looks in Leaflet's tile cache for the current tile, and

--- a/man/addRasterImage.Rd
+++ b/man/addRasterImage.Rd
@@ -6,9 +6,10 @@
 \title{Add a raster image as a layer}
 \usage{
 addRasterImage(map, x, colors = if (raster::is.factor(x)) "Set1" else
-  "Spectral", layerId = NULL, group = NULL, project = TRUE,
-  method = c("auto", "bilinear", "ngb"), maxBytes = 4 * 1024 * 1024,
-  options = tileOptions(), data = getMapData(map))
+  "Spectral", opacity = NULL, attribution = NULL, layerId = NULL,
+  group = NULL, project = TRUE, method = c("auto", "bilinear", "ngb"),
+  maxBytes = 4 * 1024 * 1024, options = tileOptions(),
+  data = getMapData(map))
 
 projectRasterForLeaflet(x, method)
 }
@@ -20,6 +21,12 @@ projectRasterForLeaflet(x, method)
 \item{colors}{the color palette (see \code{\link{colorNumeric}}) or function
 to use to color the raster values (hint: if providing a function, set
 \code{na.color} to \code{"#00000000"} to make \code{NA} areas transparent)}
+
+\item{opacity}{the base opacity of the raster, expressed from 0 to 1
+(if set will overwrite \code{options})}
+
+\item{attribution}{the HTML string to show as the attribution for this layer
+(can be also passed via \code{options})}
 
 \item{layerId}{the layer id}
 

--- a/man/addRasterImage.Rd
+++ b/man/addRasterImage.Rd
@@ -23,10 +23,10 @@ to use to color the raster values (hint: if providing a function, set
 \code{na.color} to \code{"#00000000"} to make \code{NA} areas transparent)}
 
 \item{opacity}{the base opacity of the raster, expressed from 0 to 1
-(if set will overwrite \code{options})}
+(deprecated, if set will overwrite \code{options})}
 
 \item{attribution}{the HTML string to show as the attribution for this layer
-(can be also passed via \code{options})}
+(deprecated, if set will overwrite \code{options})}
 
 \item{layerId}{the layer id}
 

--- a/man/addRasterImage.Rd
+++ b/man/addRasterImage.Rd
@@ -6,9 +6,9 @@
 \title{Add a raster image as a layer}
 \usage{
 addRasterImage(map, x, colors = if (raster::is.factor(x)) "Set1" else
-  "Spectral", opacity = 1, attribution = NULL, layerId = NULL,
-  group = NULL, project = TRUE, method = c("auto", "bilinear", "ngb"),
-  maxBytes = 4 * 1024 * 1024, data = getMapData(map))
+  "Spectral", layerId = NULL, group = NULL, project = TRUE,
+  method = c("auto", "bilinear", "ngb"), maxBytes = 4 * 1024 * 1024,
+  options = tileOptions(), data = getMapData(map))
 
 projectRasterForLeaflet(x, method)
 }
@@ -20,10 +20,6 @@ projectRasterForLeaflet(x, method)
 \item{colors}{the color palette (see \code{\link{colorNumeric}}) or function
 to use to color the raster values (hint: if providing a function, set
 \code{na.color} to \code{"#00000000"} to make \code{NA} areas transparent)}
-
-\item{opacity}{the base opacity of the raster, expressed from 0 to 1}
-
-\item{attribution}{the HTML string to show as the attribution for this layer}
 
 \item{layerId}{the layer id}
 
@@ -43,6 +39,9 @@ Ignored if \code{project = FALSE}. See \code{\link{projectRaster}} for details.}
 
 \item{maxBytes}{the maximum number of bytes to allow for the projected image
 (before base64 encoding); defaults to 4MB.}
+
+\item{options}{a list of extra options for tile layers, popups, paths
+(circles, rectangles, polygons, ...), or other map elements}
 
 \item{data}{the data object from which the argument values are derived; by
 default, it is the \code{data} object provided to \code{leaflet()}
@@ -82,4 +81,7 @@ crs(r) <- CRS("+init=epsg:4326")
 
 leaflet() \%>\% addTiles() \%>\%
   addRasterImage(r, colors = "Spectral", opacity = 0.8)
+}
+\seealso{
+\code{\link{tileOptions}}
 }


### PR DESCRIPTION
This is a fix for #507 and deals more generally with `tileOptions` in `addRasterImage()`.
The issue also links to other related issues in downstream packages.

The PR is backward compatible and raises a deprecation warning for the now overfluous arguments `opacity` and `attribution`.


PR task list:
- [x] Update NEWS
- [x] Add tests (if appropriate) [not appropriate? didn't find any existing tests]
- [x] Update documentation with `devtools::document()`
