### PR TITLE
set labelOptions(sticky = TRUE) by default

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -546,6 +546,7 @@ safeLabel <- function(label, data) {
 #' @param
 #' noHide,direction,offset,textsize,textOnly,style,permanent
 #' label options; see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-option}
+#' @param sticky If true, the tooltip will follow the mouse instead of being fixed at the feature center. Default value is \code{TRUE} (different from leaflet.js \code{FALSE}); see \url{http://leafletjs.com/reference-1.3.0.html#tooltip-sticky}
 #' @describeIn map-options Options for labels
 #' @export
 labelOptions <- function(
@@ -561,6 +562,7 @@ labelOptions <- function(
   textOnly = FALSE,
   style = NULL,
   zoomAnimation = TRUE,
+  sticky = TRUE,
   ...
 ) {
   # use old (Leaflet 0.7.x) clickable if provided

--- a/R/layers.R
+++ b/R/layers.R
@@ -574,7 +574,7 @@ labelOptions <- function(
     interactive = interactive, permanent = permanent, direction = direction,
     opacity = opacity, offset = offset,
     textsize = textsize, textOnly = textOnly, style = style,
-    zoomAnimation = zoomAnimation, className = className, ...
+    zoomAnimation = zoomAnimation, className = className, sticky = sticky, ...
   ))
 }
 

--- a/R/layers.R
+++ b/R/layers.R
@@ -481,6 +481,8 @@ addPopups <- function(
 #' @param
 #' maxWidth,minWidth,maxHeight,autoPan,keepInView,closeButton,zoomAnimation,closeOnClick
 #' popup options; see \url{http://leafletjs.com/reference-1.3.1.html#popup-option}
+#' @param zoomAnimation deprecated. See https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5
+#' @param ... extra arguments supplied to Leaflet.js popupOptions. See \url{http://leafletjs.com/reference-1.3.1.html#popup-option}
 #' @describeIn map-options Options for popups
 #' @export
 popupOptions <- function(
@@ -490,15 +492,18 @@ popupOptions <- function(
   autoPan = TRUE,
   keepInView = FALSE,
   closeButton = TRUE,
-  zoomAnimation = TRUE,
+  zoomAnimation = NULL,
   closeOnClick = NULL,
   className = "",
   ...
 ) {
+  if (!missing(zoomAnimation)) {
+    zoomAnimationWarning()
+  }
   filterNULL(list(
     maxWidth = maxWidth, minWidth = minWidth, maxHeight = maxHeight,
     autoPan = autoPan, keepInView = keepInView, closeButton = closeButton,
-    zoomAnimation = zoomAnimation, closeOnClick = closeOnClick, className = className, ...
+    closeOnClick = closeOnClick, className = className, ...
   ))
 }
 
@@ -547,6 +552,7 @@ safeLabel <- function(label, data) {
 #' noHide,direction,offset,textsize,textOnly,style,permanent
 #' label options; see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-option}
 #' @param sticky If true, the tooltip will follow the mouse instead of being fixed at the feature center. Default value is \code{TRUE} (different from leaflet.js \code{FALSE}); see \url{http://leafletjs.com/reference-1.3.0.html#tooltip-sticky}
+#' @param zoomAnimation deprecated. See \url{https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5}
 #' @describeIn map-options Options for labels
 #' @export
 labelOptions <- function(
@@ -561,7 +567,7 @@ labelOptions <- function(
   textsize = "10px",
   textOnly = FALSE,
   style = NULL,
-  zoomAnimation = TRUE,
+  zoomAnimation = NULL,
   sticky = TRUE,
   ...
 ) {
@@ -569,12 +575,16 @@ labelOptions <- function(
  if (!is.null(clickable) && interactive != clickable) interactive <- clickable
   # use old noHide if provided
  if (!is.null(noHide) && permanent != noHide) permanent <- noHide
+ if (!missing(zoomAnimation)) {
+   zoomAnimationWarning()
+ }
+
 
   filterNULL(list(
     interactive = interactive, permanent = permanent, direction = direction,
     opacity = opacity, offset = offset,
     textsize = textsize, textOnly = textOnly, style = style,
-    zoomAnimation = zoomAnimation, className = className, sticky = sticky, ...
+    className = className, sticky = sticky, ...
   ))
 }
 
@@ -1316,4 +1326,10 @@ layersControlOptions <- function(collapsed = TRUE, autoZIndex = TRUE, ...) {
 #' @export
 removeLayersControl <- function(map) {
   invokeMethod(map, NULL, "removeLayersControl")
+}
+
+
+
+zoomAnimationWarning <- function() {
+  warning("zoomAnimation has been deprecated by Leaflet.js. See https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5\nignoring 'zoomAnimation' parameter")
 }

--- a/R/layers.R
+++ b/R/layers.R
@@ -481,8 +481,6 @@ addPopups <- function(
 #' @param
 #' maxWidth,minWidth,maxHeight,autoPan,keepInView,closeButton,closeOnClick
 #' popup options; see \url{http://leafletjs.com/reference-1.3.1.html#popup-option}
-#' @param zoomAnimation deprecated. See https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5
-#' @param ... extra arguments supplied to Leaflet.js popupOptions. See \url{http://leafletjs.com/reference-1.3.1.html#popup-option}
 #' @describeIn map-options Options for popups
 #' @export
 popupOptions <- function(
@@ -549,9 +547,9 @@ safeLabel <- function(label, data) {
 }
 
 #' @param
-#' noHide,direction,offset,style,permanent
+#' noHide,direction,offset,permanent
 #' label options; see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-option}
-#' @param opacity Tooltip container opacity. Default value is \code{1} (different from leaflet.js \code{0.9}); see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-opacity}
+#' @param opacity Tooltip container opacity. Ranges from 0 to 1. Default value is \code{1} (different from leaflet.js \code{0.9}); see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-opacity}
 #' @param textsize Change the text size of a single tooltip
 #' @param textOnly Display only the text, no regular surrounding box.
 #' @param style list of css style to be added to the tooltip
@@ -879,7 +877,7 @@ b64EncodePackedIcons <- function(packedIcons) {
 #' @param interactive whether the element emits mouse events
 #' @param clickable DEPRECATED! Use the \code{interactive} option.
 #' @param
-#'   draggable,keyboard,title,alt,zIndexOffset,opacity,riseOnHover,riseOffset
+#'   draggable,keyboard,title,alt,zIndexOffset,riseOnHover,riseOffset
 #'   marker options; see \url{http://leafletjs.com/reference-1.3.1.html#marker-option}
 #' @describeIn map-options Options for markers
 #' @export

--- a/R/layers.R
+++ b/R/layers.R
@@ -479,7 +479,7 @@ addPopups <- function(
 
 #' @param className a CSS class name set on an element
 #' @param
-#' maxWidth,minWidth,maxHeight,autoPan,keepInView,closeButton,zoomAnimation,closeOnClick
+#' maxWidth,minWidth,maxHeight,autoPan,keepInView,closeButton,closeOnClick
 #' popup options; see \url{http://leafletjs.com/reference-1.3.1.html#popup-option}
 #' @param zoomAnimation deprecated. See https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5
 #' @param ... extra arguments supplied to Leaflet.js popupOptions. See \url{http://leafletjs.com/reference-1.3.1.html#popup-option}
@@ -549,10 +549,14 @@ safeLabel <- function(label, data) {
 }
 
 #' @param
-#' noHide,direction,offset,textsize,textOnly,style,permanent
+#' noHide,direction,offset,style,permanent
 #' label options; see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-option}
-#' @param sticky If true, the tooltip will follow the mouse instead of being fixed at the feature center. Default value is \code{TRUE} (different from leaflet.js \code{FALSE}); see \url{http://leafletjs.com/reference-1.3.0.html#tooltip-sticky}
+#' @param opacity Tooltip container opacity. Default value is \code{1} (different from leaflet.js \code{0.9}); see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-opacity}
+#' @param textsize Change the text size of a single tooltip
+#' @param textOnly Display only the text, no regular surrounding box.
+#' @param style list of css style to be added to the tooltip
 #' @param zoomAnimation deprecated. See \url{https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5}
+#' @param sticky If true, the tooltip will follow the mouse instead of being fixed at the feature center. Default value is \code{TRUE} (different from leaflet.js \code{FALSE}); see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-sticky}
 #' @describeIn map-options Options for labels
 #' @export
 labelOptions <- function(
@@ -616,6 +620,8 @@ addMarkers <- function(
   clusterId = NULL,
   data = getMapData(map)
 ) {
+  if (missing(labelOptions)) labelOptions <- labelOptions()
+
   if (!is.null(icon)) {
     # If custom icons are specified, we need to 1) deduplicate any URLs/files,
     # so we can efficiently send e.g. 1000 markers that all use the same 2
@@ -678,6 +684,8 @@ addLabelOnlyMarkers <- function(
   clusterId = NULL,
   data = getMapData(map)
 ) {
+  if (missing(labelOptions)) labelOptions <- labelOptions()
+
   do.call(addMarkers, filterNULL(list(
     map = map, lng = lng, lat = lat, layerId = layerId,
     group = group,
@@ -964,6 +972,8 @@ addCircleMarkers <- function(
   clusterId = NULL,
   data = getMapData(map)
 ) {
+  if (missing(labelOptions)) labelOptions <- labelOptions()
+
   options <- c(options, filterNULL(list(
     stroke = stroke, color = color, weight = weight, opacity = opacity,
     fill = fill, fillColor = fillColor, fillOpacity = fillOpacity,
@@ -1089,6 +1099,8 @@ addCircles <- function(
   highlightOptions = NULL,
   data = getMapData(map)
 ) {
+  if (missing(labelOptions)) labelOptions <- labelOptions()
+
   options <- c(options, filterNULL(list(
     stroke = stroke, color = color, weight = weight, opacity = opacity,
     fill = fill, fillColor = fillColor, fillOpacity = fillOpacity,
@@ -1127,6 +1139,8 @@ addPolylines <- function(
   highlightOptions = NULL,
   data = getMapData(map)
 ) {
+  if (missing(labelOptions)) labelOptions <- labelOptions()
+
   options <- c(options, filterNULL(list(
     stroke = stroke, color = color, weight = weight, opacity = opacity,
     fill = fill, fillColor = fillColor, fillOpacity = fillOpacity,
@@ -1162,6 +1176,8 @@ addRectangles <- function(
   highlightOptions = NULL,
   data = getMapData(map)
 ) {
+  if (missing(labelOptions)) labelOptions <- labelOptions()
+
   options <- c(options, filterNULL(list(
     stroke = stroke, color = color, weight = weight, opacity = opacity,
     fill = fill, fillColor = fillColor, fillOpacity = fillOpacity,
@@ -1204,6 +1220,8 @@ addPolygons <- function(
   highlightOptions = NULL,
   data = getMapData(map)
 ) {
+  if (missing(labelOptions)) labelOptions <- labelOptions()
+
   options <- c(options, filterNULL(list(
     stroke = stroke, color = color, weight = weight, opacity = opacity,
     fill = fill, fillColor = fillColor, fillOpacity = fillOpacity,

--- a/R/plugin-awesomeMarkers.R
+++ b/R/plugin-awesomeMarkers.R
@@ -260,6 +260,7 @@ addAwesomeMarkers <- function(
   clusterId = NULL,
   data = getMapData(map)
 ) {
+  if (missing(labelOptions)) labelOptions <- labelOptions()
   map$dependencies <- c(map$dependencies, leafletAwesomeMarkersDependencies())
 
   if (!is.null(icon)) {

--- a/man/map-options.Rd
+++ b/man/map-options.Rd
@@ -21,12 +21,12 @@ WMSTileOptions(styles = "", format = "image/jpeg", transparent = FALSE,
 
 popupOptions(maxWidth = 300, minWidth = 50, maxHeight = NULL,
   autoPan = TRUE, keepInView = FALSE, closeButton = TRUE,
-  zoomAnimation = TRUE, closeOnClick = NULL, className = "", ...)
+  zoomAnimation = NULL, closeOnClick = NULL, className = "", ...)
 
 labelOptions(interactive = FALSE, clickable = NULL, noHide = NULL,
   permanent = FALSE, className = "", direction = "auto", offset = c(0,
   0), opacity = 1, textsize = "10px", textOnly = FALSE, style = NULL,
-  zoomAnimation = TRUE, sticky = TRUE, ...)
+  zoomAnimation = NULL, sticky = TRUE, ...)
 
 markerOptions(interactive = TRUE, clickable = NULL, draggable = FALSE,
   keyboard = TRUE, title = "", alt = "", zIndexOffset = 0,
@@ -58,7 +58,9 @@ transparency}
 
 \item{crs}{Coordinate Reference System to use for the WMS requests, defaults.}
 
-\item{maxWidth, minWidth, maxHeight, autoPan, keepInView, closeButton, zoomAnimation, closeOnClick}{popup options; see \url{http://leafletjs.com/reference-1.3.1.html#popup-option}}
+\item{maxWidth, minWidth, maxHeight, autoPan, keepInView, closeButton, closeOnClick}{popup options; see \url{http://leafletjs.com/reference-1.3.1.html#popup-option}}
+
+\item{zoomAnimation}{deprecated. See https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5}
 
 \item{className}{a CSS class name set on an element}
 
@@ -99,6 +101,8 @@ See \url{https://github.com/ghybs/Leaflet.MarkerCluster.Freezable#api-reference}
 
 \item{pointerEvents}{sets the \code{pointer-events} attribute on the path if
 SVG backend is used}
+
+\item{zoomAnimation}{deprecated. See \url{https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5}}
 }
 \description{
 The rest of all possible options for map elements and layers that are not

--- a/man/map-options.Rd
+++ b/man/map-options.Rd
@@ -26,7 +26,7 @@ popupOptions(maxWidth = 300, minWidth = 50, maxHeight = NULL,
 labelOptions(interactive = FALSE, clickable = NULL, noHide = NULL,
   permanent = FALSE, className = "", direction = "auto", offset = c(0,
   0), opacity = 1, textsize = "10px", textOnly = FALSE, style = NULL,
-  zoomAnimation = TRUE, ...)
+  zoomAnimation = TRUE, sticky = TRUE, ...)
 
 markerOptions(interactive = TRUE, clickable = NULL, draggable = FALSE,
   keyboard = TRUE, title = "", alt = "", zIndexOffset = 0,
@@ -67,6 +67,8 @@ transparency}
 \item{clickable}{DEPRECATED! Use the \code{interactive} option.}
 
 \item{noHide, direction, offset, textsize, textOnly, style, permanent}{label options; see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-option}}
+
+\item{sticky}{If true, the tooltip will follow the mouse instead of being fixed at the feature center. Default value is \code{TRUE} (different from leaflet.js \code{FALSE}); see \url{http://leafletjs.com/reference-1.3.0.html#tooltip-sticky}}
 
 \item{draggable, keyboard, title, alt, zIndexOffset, opacity, riseOnHover, riseOffset}{marker options; see \url{http://leafletjs.com/reference-1.3.1.html#marker-option}}
 

--- a/man/map-options.Rd
+++ b/man/map-options.Rd
@@ -44,6 +44,8 @@ pathOptions(lineCap = NULL, lineJoin = NULL, clickable = NULL,
 \item{minZoom, maxZoom, maxNativeZoom, tileSize, subdomains, errorTileUrl, tms, noWrap, zoomOffset, zoomReverse, zIndex, unloadInvisibleTiles, updateWhenIdle, detectRetina}{the tile layer options; see
 \url{http://leafletjs.com/reference-1.3.1.html#tilelayer}}
 
+\item{opacity}{Tooltip container opacity. Default value is \code{1} (different from leaflet.js \code{0.9}); see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-opacity}}
+
 \item{...}{extra options passed to underlying Javascript object constructor.}
 
 \item{styles}{comma-separated list of WMS styles}
@@ -68,9 +70,15 @@ transparency}
 
 \item{clickable}{DEPRECATED! Use the \code{interactive} option.}
 
-\item{noHide, direction, offset, textsize, textOnly, style, permanent}{label options; see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-option}}
+\item{noHide, direction, offset, style, permanent}{label options; see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-option}}
 
-\item{sticky}{If true, the tooltip will follow the mouse instead of being fixed at the feature center. Default value is \code{TRUE} (different from leaflet.js \code{FALSE}); see \url{http://leafletjs.com/reference-1.3.0.html#tooltip-sticky}}
+\item{textsize}{Change the text size of a single tooltip}
+
+\item{textOnly}{Display only the text, no regular surrounding box.}
+
+\item{style}{list of css style to be added to the tooltip}
+
+\item{sticky}{If true, the tooltip will follow the mouse instead of being fixed at the feature center. Default value is \code{TRUE} (different from leaflet.js \code{FALSE}); see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-sticky}}
 
 \item{draggable, keyboard, title, alt, zIndexOffset, opacity, riseOnHover, riseOffset}{marker options; see \url{http://leafletjs.com/reference-1.3.1.html#marker-option}}
 
@@ -101,6 +109,8 @@ See \url{https://github.com/ghybs/Leaflet.MarkerCluster.Freezable#api-reference}
 
 \item{pointerEvents}{sets the \code{pointer-events} attribute on the path if
 SVG backend is used}
+
+\item{...}{extra arguments supplied to Leaflet.js popupOptions. See \url{http://leafletjs.com/reference-1.3.1.html#popup-option}}
 
 \item{zoomAnimation}{deprecated. See \url{https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5}}
 }

--- a/man/map-options.Rd
+++ b/man/map-options.Rd
@@ -44,7 +44,7 @@ pathOptions(lineCap = NULL, lineJoin = NULL, clickable = NULL,
 \item{minZoom, maxZoom, maxNativeZoom, tileSize, subdomains, errorTileUrl, tms, noWrap, zoomOffset, zoomReverse, zIndex, unloadInvisibleTiles, updateWhenIdle, detectRetina}{the tile layer options; see
 \url{http://leafletjs.com/reference-1.3.1.html#tilelayer}}
 
-\item{opacity}{Tooltip container opacity. Default value is \code{1} (different from leaflet.js \code{0.9}); see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-opacity}}
+\item{opacity}{Tooltip container opacity. Ranges from 0 to 1. Default value is \code{1} (different from leaflet.js \code{0.9}); see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-opacity}}
 
 \item{...}{extra options passed to underlying Javascript object constructor.}
 
@@ -62,7 +62,7 @@ transparency}
 
 \item{maxWidth, minWidth, maxHeight, autoPan, keepInView, closeButton, closeOnClick}{popup options; see \url{http://leafletjs.com/reference-1.3.1.html#popup-option}}
 
-\item{zoomAnimation}{deprecated. See https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5}
+\item{zoomAnimation}{deprecated. See \url{https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5}}
 
 \item{className}{a CSS class name set on an element}
 
@@ -70,7 +70,7 @@ transparency}
 
 \item{clickable}{DEPRECATED! Use the \code{interactive} option.}
 
-\item{noHide, direction, offset, style, permanent}{label options; see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-option}}
+\item{noHide, direction, offset, permanent}{label options; see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-option}}
 
 \item{textsize}{Change the text size of a single tooltip}
 
@@ -80,7 +80,7 @@ transparency}
 
 \item{sticky}{If true, the tooltip will follow the mouse instead of being fixed at the feature center. Default value is \code{TRUE} (different from leaflet.js \code{FALSE}); see \url{http://leafletjs.com/reference-1.3.1.html#tooltip-sticky}}
 
-\item{draggable, keyboard, title, alt, zIndexOffset, opacity, riseOnHover, riseOffset}{marker options; see \url{http://leafletjs.com/reference-1.3.1.html#marker-option}}
+\item{draggable, keyboard, title, alt, zIndexOffset, riseOnHover, riseOffset}{marker options; see \url{http://leafletjs.com/reference-1.3.1.html#marker-option}}
 
 \item{showCoverageOnHover}{when you mouse over a cluster it shows the bounds
 of its markers}
@@ -109,10 +109,6 @@ See \url{https://github.com/ghybs/Leaflet.MarkerCluster.Freezable#api-reference}
 
 \item{pointerEvents}{sets the \code{pointer-events} attribute on the path if
 SVG backend is used}
-
-\item{...}{extra arguments supplied to Leaflet.js popupOptions. See \url{http://leafletjs.com/reference-1.3.1.html#popup-option}}
-
-\item{zoomAnimation}{deprecated. See \url{https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#api-changes-5}}
 }
 \description{
 The rest of all possible options for map elements and layers that are not

--- a/tests/testit/test-remote.R
+++ b/tests/testit/test-remote.R
@@ -152,8 +152,11 @@ assert(
   identical(mockSession$.calls, list())
 )
 mockSession$.flush()
-expected <- list(structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addPolygons\",\"args\":[[[[{\"lng\":[1,2,3,4,5],\"lat\":[1,2,3,4,5]}]]],null,null,{\"interactive\":true,\"className\":\"\",\"stroke\":true,\"color\":\"#03F\",\"weight\":5,\"opacity\":0.5,\"fill\":true,\"fillColor\":\"#03F\",\"fillOpacity\":0.2,\"smoothFactor\":1,\"noClip\":false},null,null,null,null,null]}]}", class = "json")), .Names = c("type", # nolint
-  "message")))
+# nolint start
+expected <- list(structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addPolygons\",\"args\":[[[[{\"lng\":[1,2,3,4,5],\"lat\":[1,2,3,4,5]}]]],null,null,{\"interactive\":true,\"className\":\"\",\"stroke\":true,\"color\":\"#03F\",\"weight\":5,\"opacity\":0.5,\"fill\":true,\"fillColor\":\"#03F\",\"fillOpacity\":0.2,\"smoothFactor\":1,\"noClip\":false},null,null,null,{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},null]}]}", class = "json")), .Names = c("type",
+"message")))
+# nolint end
+
 dput(mockSession$.calls)
 assert(identical(mockSession$.calls, expected))
 
@@ -168,7 +171,8 @@ remote2 <- leafletProxy("map", mockSession,
 )
 # Check that addMarkers() takes effect immediately, no flush required
 remote2 %>% addMarkers()
-expected2 <- list(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addMarkers\",\"args\":[[10,9,8,7,6,5,4,3,2,1],[10,9,8,7,6,5,4,3,2,1],null,null,null,{\"interactive\":true,\"draggable\":false,\"keyboard\":true,\"title\":\"\",\"alt\":\"\",\"zIndexOffset\":0,\"opacity\":1,\"riseOnHover\":false,\"riseOffset\":250},null,null,null,null,null,null,null]}]}", class = "json"))) # nolint
+expected2 <- list(structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addMarkers\",\"args\":[[10,9,8,7,6,5,4,3,2,1],[10,9,8,7,6,5,4,3,2,1],null,null,null,{\"interactive\":true,\"draggable\":false,\"keyboard\":true,\"title\":\"\",\"alt\":\"\",\"zIndexOffset\":0,\"opacity\":1,\"riseOnHover\":false,\"riseOffset\":250},null,null,null,null,null,{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},null]}]}", class = "json")), .Names = c("type",
+"message"))) # nolint
 # cat(deparse(mockSession$.calls), "\n")
 assert(identical(mockSession$.calls, expected2))
 # Flushing should do nothing
@@ -185,7 +189,11 @@ remote3 <- leafletProxy("map", mockSession,
 remote3 %>% clearShapes() %>% addMarkers()
 assert(identical(mockSession$.calls, list()))
 mockSession$.flush()
-expected3 <- list(structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"clearShapes\",\"args\":[]}]}", class = "json")), .Names = c("type", "message")), structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addMarkers\",\"args\":[[10,9,8,7,6,5,4,3,2,1],[10,9,8,7,6,5,4,3,2,1],null,null,null,{\"interactive\":true,\"draggable\":false,\"keyboard\":true,\"title\":\"\",\"alt\":\"\",\"zIndexOffset\":0,\"opacity\":1,\"riseOnHover\":false,\"riseOffset\":250},null,null,null,null,null,null,null]}]}", class = "json")), .Names = c("type", "message"))) # nolint
+# nolint start
+expected3 <- list(structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"clearShapes\",\"args\":[]}]}", class = "json")), .Names = c("type",
+"message")), structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addMarkers\",\"args\":[[10,9,8,7,6,5,4,3,2,1],[10,9,8,7,6,5,4,3,2,1],null,null,null,{\"interactive\":true,\"draggable\":false,\"keyboard\":true,\"title\":\"\",\"alt\":\"\",\"zIndexOffset\":0,\"opacity\":1,\"riseOnHover\":false,\"riseOffset\":250},null,null,null,null,null,{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},null]}]}", class = "json")), .Names = c("type",
+"message")))
+# nolint end
 
 # Check that multiple calls are invoked in order
 assert(identical(mockSession$.calls, expected3))


### PR DESCRIPTION
Adds a sticky tooltip by default.

```r
# sticky = TRUE; sticks to mouse
leaflet() %>%
  addTiles() %>%
  addPolygons(data = gadmCHE, label = ~NAME_1)

# sticky = TRUE; sticks to mouse
leaflet() %>%
  addTiles() %>%
  addPolygons(data = gadmCHE, label = ~NAME_1, 
              labelOptions = labelOptions(sticky = TRUE))

# sticky = FALSE; displayed in 'center'
leaflet() %>%
  addTiles() %>%
  addPolygons(data = gadmCHE, label = ~NAME_1, 
              labelOptions = labelOptions(sticky = FALSE))
```

PR task list:
- [X] Update documentation with `devtools::document()`
