### PR TITLE
add note about preferCanvas in leafletOptions()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -64,6 +64,9 @@ BUG FIXES AND FEATURES
 
 * Added `data` parameter to remaining `addXXX()` methods, including addLegend. (f273edd, #491, #485)
 
+* Added `preferCanvas = FALSE` argument to `leafletOptions()` (#521)
+
+
 leaflet 1.1.0
 --------------------------------------------------------------------------------
 

--- a/R/leaflet.R
+++ b/R/leaflet.R
@@ -137,6 +137,7 @@ leafletOptions <- function(
       maxZoom = maxZoom,
       crs = crs,
       worldCopyJump = worldCopyJump,
+      preferCanvas = preferCanvas,
       ...)
   )
 }

--- a/R/leaflet.R
+++ b/R/leaflet.R
@@ -119,15 +119,17 @@ mapOptions <- function(map, zoomToLimits = c("always", "first", "never")) {
 #' @param  crs Coordinate Reference System to use. Don't change this if you're not sure what it means.
 #' @seealso \code{\link{leafletCRS}} for creating a custom CRS.
 #' @param  worldCopyJump With this option enabled, the map tracks when you pan to another "copy" of the world and seamlessly jumps to the original one so that all overlays like markers and vector layers are still visible.
-#' @param ... other options.
+#' @param preferCanvas Whether leaflet.js Paths should be rendered on a Canvas renderer. By default, all Paths are rendered in a SVG renderer.
+#' @param ... other options used for leaflet.js map creation.
 #' @describeIn leaflet Options for map creation
-#' @seealso \url{http://leafletjs.com/reference-1.3.1.html#map-option} for details.
+#' @seealso See \url{http://leafletjs.com/reference-1.3.1.html#map-option} for details and more options.
 #' @export
 leafletOptions <- function(
   minZoom = NULL,
   maxZoom = NULL,
   crs = leafletCRS(),
   worldCopyJump = NULL,
+  preferCanvas = FALSE,
   ...) {
   filterNULL(
     list(

--- a/man/leaflet.Rd
+++ b/man/leaflet.Rd
@@ -10,7 +10,7 @@ leaflet(data = NULL, width = NULL, height = NULL, padding = 0,
   options = leafletOptions(), elementId = NULL)
 
 leafletOptions(minZoom = NULL, maxZoom = NULL, crs = leafletCRS(),
-  worldCopyJump = NULL, ...)
+  worldCopyJump = NULL, preferCanvas = FALSE, ...)
 
 leafletCRS(crsClass = "L.CRS.EPSG3857", code = NULL, proj4def = NULL,
   projectedBounds = NULL, origin = NULL, transformation = NULL,
@@ -44,7 +44,9 @@ spatial data frames from the \pkg{sf} package.}
 
 \item{worldCopyJump}{With this option enabled, the map tracks when you pan to another "copy" of the world and seamlessly jumps to the original one so that all overlays like markers and vector layers are still visible.}
 
-\item{...}{other options.}
+\item{preferCanvas}{Whether leaflet.js Paths should be rendered on a Canvas renderer. By default, all Paths are rendered in a SVG renderer.}
+
+\item{...}{other options used for leaflet.js map creation.}
 
 \item{crsClass}{One of L.CRS.EPSG3857, L.CRS.EPSG4326, L.CRS.EPSG3395,
 L.CRS.Simple, L.Proj.CRS}
@@ -263,5 +265,5 @@ m \%>\% addCircleMarkers(~lng, ~lat, radius = ~size,
 \seealso{
 \code{\link{leafletCRS}} for creating a custom CRS.
 
-\url{http://leafletjs.com/reference-1.3.1.html#map-option} for details.
+See \url{http://leafletjs.com/reference-1.3.1.html#map-option} for details and more options.
 }


### PR DESCRIPTION
Fixes https://github.com/rstudio/leaflet/issues/463#issuecomment-380124722

```
Added `preferCanvas = FALSE` argument to `leafletOptions()` (#521)
```

```
library(leaflet)
# right click on polygon, should be a 'regular' right click (SVG) (back, forward, reload, print, etc.)
leaflet() %>%
  addTiles() %>%
  addPolygons(data = gadmCHE, label = ~NAME_1)

# right click on polygon, should ask about saving an image or copying an image
leaflet(options = leafletOptions(preferCanvas = TRUE)) %>%
  addTiles() %>%
  addPolygons(data = gadmCHE, label = ~NAME_1)

# right click on polygon, should be a 'regular' right click (SVG)
leaflet(options = leafletOptions(preferCanvas = FALSE)) %>%
  addTiles() %>%
  addPolygons(data = gadmCHE, label = ~NAME_1)
```



PR task list:
- [x] Update NEWS
- [x] Update documentation with `devtools::document()`
