### PR TITLE
allow all pointer events on popup tip container

### DIFF
--- a/inst/htmlwidgets/lib/rstudio_leaflet/rstudio_leaflet.css
+++ b/inst/htmlwidgets/lib/rstudio_leaflet/rstudio_leaflet.css
@@ -18,3 +18,10 @@
   border-right: 6px solid transparent;
   /* right: -16px; */
 }
+
+.leaflet-popup-pane .leaflet-popup-tip-container {
+  /* when the tooltip container is clicked, it is closed */
+  pointer-events: all;
+  /* tooltips should display the "hand" icon, just like .leaflet-interactive*/
+  cursor: pointer;
+}


### PR DESCRIPTION
Fixes #519

`pointer-events` were blocked in css. Unblocked by setting all `pointer-events` to `all`.

Added cursor shape to match regular map interaction

```r
library(leaflet)

leaflet() %>%
  addTiles() %>%
  addPolygons(data = gadmCHE, 
              popup = ~NAME_1)
```