### PR TITLE
preferCanvas = NULL will be filtered out, but still exposes variable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -64,7 +64,7 @@ BUG FIXES AND FEATURES
 
 * Added `data` parameter to remaining `addXXX()` methods, including addLegend. (f273edd, #491, #485)
 
-* Added `preferCanvas = FALSE` argument to `leafletOptions()` (#521)
+* Added `preferCanvas` argument to `leafletOptions()` (#521)
 
 
 leaflet 1.1.0

--- a/R/leaflet.R
+++ b/R/leaflet.R
@@ -119,7 +119,7 @@ mapOptions <- function(map, zoomToLimits = c("always", "first", "never")) {
 #' @param  crs Coordinate Reference System to use. Don't change this if you're not sure what it means.
 #' @seealso \code{\link{leafletCRS}} for creating a custom CRS.
 #' @param  worldCopyJump With this option enabled, the map tracks when you pan to another "copy" of the world and seamlessly jumps to the original one so that all overlays like markers and vector layers are still visible.
-#' @param preferCanvas Whether leaflet.js Paths should be rendered on a Canvas renderer. By default, all Paths are rendered in a SVG renderer.
+#' @param preferCanvas Whether leaflet.js Paths should be rendered on a Canvas renderer. 
 #' @param ... other options used for leaflet.js map creation.
 #' @describeIn leaflet Options for map creation
 #' @seealso See \url{http://leafletjs.com/reference-1.3.1.html#map-option} for details and more options.
@@ -129,7 +129,7 @@ leafletOptions <- function(
   maxZoom = NULL,
   crs = leafletCRS(),
   worldCopyJump = NULL,
-  preferCanvas = FALSE,
+  preferCanvas = NULL,
   ...) {
   filterNULL(
     list(

--- a/man/leaflet.Rd
+++ b/man/leaflet.Rd
@@ -10,7 +10,7 @@ leaflet(data = NULL, width = NULL, height = NULL, padding = 0,
   options = leafletOptions(), elementId = NULL)
 
 leafletOptions(minZoom = NULL, maxZoom = NULL, crs = leafletCRS(),
-  worldCopyJump = NULL, preferCanvas = FALSE, ...)
+  worldCopyJump = NULL, preferCanvas = NULL, ...)
 
 leafletCRS(crsClass = "L.CRS.EPSG3857", code = NULL, proj4def = NULL,
   projectedBounds = NULL, origin = NULL, transformation = NULL,
@@ -44,7 +44,7 @@ spatial data frames from the \pkg{sf} package.}
 
 \item{worldCopyJump}{With this option enabled, the map tracks when you pan to another "copy" of the world and seamlessly jumps to the original one so that all overlays like markers and vector layers are still visible.}
 
-\item{preferCanvas}{Whether leaflet.js Paths should be rendered on a Canvas renderer. By default, all Paths are rendered in a SVG renderer.}
+\item{preferCanvas}{Whether leaflet.js Paths should be rendered on a Canvas renderer.}
 
 \item{...}{other options used for leaflet.js map creation.}
 


### PR DESCRIPTION
Tweak for #521

Set default value to NULL so the default leaflet.js behavior is kept (which is currently `false`)