### PR TITLE
Add comment about webshot being required for reprex::reprex to work

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,18 @@
 Please briefly describe your problem and what output you expect. If you have a question, please try using stackoverflow <http://stackoverflow.com> first.
 
-Please include a minimal reprex. The goal of a reprex is to make it as easy as possible for me to recreate your problem so that I can fix it. If you've never heard of a reprex before, start by reading <https://github.com/jennybc/reprex#what-is-a-reprex>, and follow the advice further down the page. Do NOT include session info unless it's explicitly asked for, or you've used `reprex::reprex(..., si = TRUE)` to hide it away.
+Please include a minimal reprex. The goal of a reprex is to make it as easy as possible for me to recreate your problem so that I can fix it. If you've never heard of a reprex before, start by reading <https://github.com/jennybc/reprex#what-is-a-reprex>, and follow the advice further down the page. Do NOT include session info unless it's explicitly asked for, or you've used `reprex::reprex(..., si = TRUE)` to hide it away.  Make sure to have `webshot` installed to have `reprex` produces images of the leaflet htmlwidgets.
+```r
+# make sure webshot is installed to take pictures of htmlwidgets
+if (!("webshot" %in% installed.packages()[, "Package"])) {
+  install.packages("webshot")
+  # restart R process to fully integrate with knitr
+}
+reprex::reprex({
+  library(leaflet)
+  # insert reprex here
+  leaflet() %>% addTiles()
+})
+```
 
 Delete these instructions once you have read them.
 
@@ -9,5 +21,7 @@ Delete these instructions once you have read them.
 Brief description of the problem
 
 ```r
+library(leaflet)
 # insert reprex here
+leaflet() %>% addTiles()
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,19 @@ We will try to be responsive and provide feedback in case we decide not to merge
 
 ## Minimal reproducible example
 
-Finally, please include a minimal reprex. The goal of a reprex is to make it as easy as possible for me to recreate your problem so that I can fix it. If you've never heard of a reprex before, start by reading <https://github.com/jennybc/reprex#what-is-a-reprex>, and follow the advice further down the page. Do NOT include session info unless it's explicitly asked for, or you've used `reprex::reprex(..., si = TRUE)` to hide it away.
+Finally, please include a minimal reprex. The goal of a reprex is to make it as easy as possible for me to recreate your problem so that I can fix it. If you've never heard of a reprex before, start by reading <https://github.com/jennybc/reprex#what-is-a-reprex>, and follow the advice further down the page. Do NOT include session info unless it's explicitly asked for, or you've used `reprex::reprex(..., si = TRUE)` to hide it away.  Make sure to have `webshot` installed to have `reprex` produces images of the leaflet htmlwidgets.
+```r
+# make sure webshot is installed to take pictures of htmlwidgets
+if (!("webshot" %in% installed.packages()[, "Package"])) {
+  install.packages("webshot")
+  # restart R process to fully integrate with knitr
+}
+reprex::reprex({
+  library(leaflet)
+  # insert reprex here
+  leaflet() %>% addTiles()
+})
+```
 
 Delete these instructions once you have read them.
 


### PR DESCRIPTION
Updates templates for github to add a note about webshot being required for reprex to work