### PR TITLE
map-pane have a z-index of 'auto'

### DIFF
--- a/inst/htmlwidgets/lib/rstudio_leaflet/rstudio_leaflet.css
+++ b/inst/htmlwidgets/lib/rstudio_leaflet/rstudio_leaflet.css
@@ -25,3 +25,8 @@
   /* tooltips should display the "hand" icon, just like .leaflet-interactive*/
   cursor: pointer;
 }
+
+/* have the widget be displayed in the right 'layer' */
+.leaflet-map-pane {
+  z-index: auto;
+}


### PR DESCRIPTION
This fixes the layout issues of leaflet having z-index values for all the panes.  By having the map-pane have a value of auto, order is preserved by order of appearance. 

