### PR TITLE
remove method changed for scalebar

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ leaflet 2.0.0.9000
 BUG FIXES
 
 * `.leaflet-map-pane` `z-index` switched to 'auto'. Allows for map panes to appear above the map if they appear later in the dom. (#537)
+* Use correct Leaflet.js scale control remove method (#547)
+
 
 leaflet 2.0.0
 --------------------------------------------------------------------------------

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -2058,7 +2058,7 @@ methods.addScaleBar = function (options) {
 
 methods.removeScaleBar = function () {
   if (this.currentScaleBar) {
-    this.currentScaleBar.removeFrom(this);
+    this.currentScaleBar.remove();
     this.currentScaleBar = null;
   }
 };

--- a/javascript/src/methods.js
+++ b/javascript/src/methods.js
@@ -896,7 +896,7 @@ methods.addScaleBar = function(options) {
 
 methods.removeScaleBar = function() {
   if (this.currentScaleBar) {
-    this.currentScaleBar.removeFrom(this);
+    this.currentScaleBar.remove();
     this.currentScaleBar = null;
   }
 };


### PR DESCRIPTION
Fixes: #538 Scalebar not removed properly in v2.0.0

``` r
library(leaflet)                                                    
                                                                    
leaf <- leaflet() %>%                                               
  addTiles() %>%                                                      
  addScaleBar()                                                       
                                                                    
# displays scalebar in top right                                    
leaf                                                                
```

![](https://i.imgur.com/dvvkMFH.png)

``` r
                                                                    
# no scalebar displayed in top right                                
leaf %>% removeScaleBar()                                           
```

![](https://i.imgur.com/gah1S2W.png)

``` r
# displays scalebar in top right with blue polygons over switzerland
leaflet() %>%                                                       
  addTiles() %>%                                                      
  addScaleBar() %>%                                                   
  addScaleBar() %>% # triggers remove scalebar internally             
  addPolygons(data = gadmCHE)                                         
#> Loading required package: sp
```

![](https://i.imgur.com/k6Q9br2.png)


PR task list:
- [x] Update NEWS
