### PR TITLE
fix broken leaflet-search mouse events within shiny

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,8 @@ leaflet 2.0.1.9000
 
 BUG FIXES and IMPROVEMENTS
 * Require viridis >= 0.5.1 to avoid namespace issues with viridisLite (#557)
-* Fixed recursive JSON object serialization issue for mouse events within shiny (#563)
+* Fixed broken mouse events after using leaflet-search from leaflet.extras within shiny applications (#563)
+
 
 
 leaflet 2.0.1

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@ leaflet 2.0.1.9000
 
 BUG FIXES and IMPROVEMENTS
 * Require viridis >= 0.5.1 to avoid namespace issues with viridisLite (#557)
+* Fixed recursive JSON object serialization issue for mouse events within shiny (#563)
+
 
 leaflet 2.0.1
 --------------------------------------------------------------------------------

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -1287,10 +1287,18 @@ function mouseHandler(mapId, layerId, group, eventName, extraInfo) {
   return function (e) {
     if (!_htmlwidgets2.default.shinyMode) return;
 
+    var latLng = e.target.getLatLng ? e.target.getLatLng() : e.latlng;
+    if (latLng) {
+      // retrieve only lat, lon values to remove prototype
+      //   and extra parameters added by 3rd party modules
+      // these objects are for json serialization, not javascript
+      var latLngVal = _leaflet2.default.latLng(latLng); // make sure it has consistent shape
+      latLng = { lat: latLngVal.lat, lon: latLngVal.lon };
+    }
     var eventInfo = _jquery2.default.extend({
       id: layerId,
       ".nonce": Math.random() // force reactivity
-    }, group !== null ? { group: group } : null, e.target.getLatLng ? e.target.getLatLng() : e.latlng, extraInfo);
+    }, group !== null ? { group: group } : null, latLng, extraInfo);
 
     _shiny2.default.onInputChange(mapId + "_" + eventName, eventInfo);
   };

--- a/javascript/src/methods.js
+++ b/javascript/src/methods.js
@@ -18,13 +18,21 @@ function mouseHandler(mapId, layerId, group, eventName, extraInfo) {
   return function(e) {
     if (!HTMLWidgets.shinyMode) return;
 
+    let latLng = e.target.getLatLng ? e.target.getLatLng() : e.latlng;
+    if (latLng) {
+      // retrieve only lat, lon values to remove prototype
+      //   and extra parameters added by 3rd party modules
+      // these objects are for json serialization, not javascript
+      let latLngVal = L.latLng(latLng); // make sure it has consistent shape
+      latLng = {lat: latLngVal.lat, lon: latLngVal.lon};
+    }
     let eventInfo = $.extend(
       {
         id: layerId,
         ".nonce": Math.random()  // force reactivity
       },
       group !== null ? {group: group} : null,
-      e.target.getLatLng ? e.target.getLatLng() : e.latlng,
+      latLng,
       extraInfo
     );
 


### PR DESCRIPTION

Search caused the latlng values to be poisoned with a layer attribute.  When the latlng value is serialized for json in method.js, this is not possible due to recursion.  This fix trims all latlng values for mouse handlers for shiny.

Original Issue: https://github.com/bhaskarvk/leaflet.extras/issues/104#issuecomment-399845514


```r
library(shiny)
library(leaflet)
library(leaflet.extras)

ui <- fluidPage(
  leafletOutput("map")
)

server <- function(input, output, session) {
  data <- data.frame(lat = 20:22, lng = 30:32, name = c("first", "second", "third"))
  
  output$map <- renderLeaflet({
    leaflet(data) %>%
      addTiles() %>%
      addMarkers(lng = ~lng, lat = ~lat, label = ~name, group = "names") %>%
      addSearchFeatures(targetGroups = "names")
  })
  
  observe({
    input$map_marker_click
    cat('clicked\n')
  })
}

shinyApp(ui, server)
```

PR task list:
- [x] Update NEWS
