### PR TITLE
fix typo of lon to lng for latLng value

### DIFF
--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -1293,7 +1293,7 @@ function mouseHandler(mapId, layerId, group, eventName, extraInfo) {
       //   and extra parameters added by 3rd party modules
       // these objects are for json serialization, not javascript
       var latLngVal = _leaflet2.default.latLng(latLng); // make sure it has consistent shape
-      latLng = { lat: latLngVal.lat, lon: latLngVal.lon };
+      latLng = { lat: latLngVal.lat, lng: latLngVal.lng };
     }
     var eventInfo = _jquery2.default.extend({
       id: layerId,

--- a/javascript/src/methods.js
+++ b/javascript/src/methods.js
@@ -24,7 +24,7 @@ function mouseHandler(mapId, layerId, group, eventName, extraInfo) {
       //   and extra parameters added by 3rd party modules
       // these objects are for json serialization, not javascript
       let latLngVal = L.latLng(latLng); // make sure it has consistent shape
-      latLng = {lat: latLngVal.lat, lon: latLngVal.lon};
+      latLng = {lat: latLngVal.lat, lng: latLngVal.lng};
     }
     let eventInfo = $.extend(
       {


### PR DESCRIPTION
Test app:

```r
library(shiny)
library(leaflet)
library(leaflet.extras)

ui <- fluidPage(
  leafletOutput("map")
)

server <- function(input, output, session) {
  data <- data.frame(lat = 20:22, lng = 30:32, name = c("first", "second", "third"))
  
  output$map <- renderLeaflet({
    leaflet(data) %>%
      addTiles() %>%
      addMarkers(lng = ~lng, lat = ~lat, label = ~name, group = "names") %>%
      addSearchFeatures(targetGroups = "names")
  })
  
  observe({
    input$map_marker_click
    cat('clicked\n')
    print(input$map_marker_click)
  })
}

shinyApp(ui, server)
```

For every click (before and after searching for 'second'), should produce console output similar to 
```
clicked
$id
NULL

$.nonce
[1] 0.5250792

$group
[1] "names"

$lat
[1] 21

$lng
[1] 31
```