### PR TITLE
invokeRemote() should resolve dependencies before calling shiny::createWebDependency

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ leaflet 2.0.3
 
 BUG FIXES and IMPROVEMENTS
 * Fixed [rstudio/crosstalk#58](https://github.com/rstudio/crosstalk/issues/58), which caused Leaflet maps that used Crosstalk shared data in Shiny apps, to be redrawn at incorrect times.
+* invokeRemote() now resolves html dependencies before passing them to shiny::createWebDependency() (#620).
 * Upgrade leaflet-provider to 1.4.0, enable more map variants such as CartoDB.Voyager (#567)
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -194,11 +194,13 @@ invokeRemote <- function(map, method, args = list()) {
   if (!inherits(map, "leaflet_proxy"))
     stop("Invalid map parameter; map proxy object was expected")
 
+  deps <- htmltools::resolveDependencies(map$dependencies)
+
   msg <- list(
     id = map$id,
     calls = list(
       list(
-        dependencies = lapply(map$dependencies, shiny::createWebDependency),
+        dependencies = lapply(deps, shiny::createWebDependency),
         method = method,
         args = args
       )


### PR DESCRIPTION
See #620