### PR TITLE
Add documentation on addSimpleGraticule

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,14 +1,8 @@
 leaflet 2.0.3.9000
 --------------------------------------------------------------------------------
 
-BREAKING CHANGES
-*
-
-FEATURES
-*
-
 BUG FIXES and IMPROVEMENTS
-*
+* Add usage of `addSimpleGraticule` function to the documentation `morefeatures.Rmd`.
 
 
 

--- a/docs/morefeatures.Rmd
+++ b/docs/morefeatures.Rmd
@@ -68,6 +68,14 @@ m %>%
     options = layersControlOptions(collapsed = FALSE))
 ```
 
+You can also consider using the `addSimpleGraticule` function (via the [Leaflet.SimpleGraticule](https://github.com/ablakey/Leaflet.SimpleGraticule) plugin) to add a graticule, which displays corresponding latitudes and longitudes in the map margin.  
+
+```{r }
+m <- leaflet() %>% addTiles() %>% setView(0,0,2)
+m %>% addSimpleGraticule()
+m %>% addSimpleGraticule(interval = 10, showOriginLabel = FALSE)
+```
+
 #### Terminator (day/night indicator)
 
 ```{r}


### PR DESCRIPTION
I missed documentation on the function `addSimpleGraticule()` in the documentation (the online 'tutorial' for using leaflet in R). I added a small section on this function in the file `morefeatures.rmd` and added a note about this change in the NEWS file.

I ran `devtools::check` (no warnings, errors, messages) but did not update documentation or the html file that can be knitted from the rmd file. This is my first ever pull request, and did not feel confident to commit the changes made to the package by my personal machine by the `devtools::check` command.

