### PR TITLE
Allow leafletProxy arguments to contain JS()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Depends: R (>= 3.1.0)
 Imports:
     base64enc,
     crosstalk,
-    htmlwidgets,
+    htmlwidgets (>= 1.5.1.9002),
     htmltools,
     magrittr,
     markdown,
@@ -61,6 +61,8 @@ Suggests:
     RJSONIO,
     purrr,
     testthat
+Remotes:
+    ramnathv/htmlwidgets
 RoxygenNote: 7.1.1
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,7 +60,7 @@ Suggests:
     R6,
     RJSONIO,
     purrr,
-    testthat
+    testthat (>= 3.0.0)
 Remotes:
     ramnathv/htmlwidgets
 RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Depends: R (>= 3.1.0)
 Imports:
     base64enc,
     crosstalk,
-    htmlwidgets (>= 1.5.1.9002),
+    htmlwidgets (>= 1.5.4),
     htmltools,
     magrittr,
     markdown,
@@ -61,8 +61,6 @@ Suggests:
     RJSONIO,
     purrr,
     testthat (>= 3.0.0)
-Remotes:
-    ramnathv/htmlwidgets
 RoxygenNote: 7.1.1
 Encoding: UTF-8
 LazyData: true

--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,7 @@ FEATURES
 *
 
 BUG FIXES and IMPROVEMENTS
-*
+* Enable JS function literals (wrapped in `htmlwidgets::JS()`) to be included in arguments to methods invoked on `leafletProxy` objects. (JS function literals could already be included with methods invoked on `leaflet` objects, so this change just brings `leafletProxy` to parity.) (#420)
 
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -203,7 +203,7 @@ invokeRemote <- function(map, method, args = list()) {
         dependencies = lapply(deps, shiny::createWebDependency),
         method = method,
         args = lapply(args, function(arg) {
-          list(value = arg, evals = htmlwidgets:::JSEvals(arg))
+          list(value = arg, evals = htmlwidgets::JSEvals(arg))
         })
       )
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -203,7 +203,7 @@ invokeRemote <- function(map, method, args = list()) {
         dependencies = lapply(deps, shiny::createWebDependency),
         method = method,
         args = lapply(args, function(arg) {
-          list(arg = arg, evals = htmlwidgets:::JSEvals(arg))
+          list(value = arg, evals = htmlwidgets:::JSEvals(arg))
         })
       )
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -202,7 +202,9 @@ invokeRemote <- function(map, method, args = list()) {
       list(
         dependencies = lapply(deps, shiny::createWebDependency),
         method = method,
-        args = args
+        args = lapply(args, function(arg) {
+          list(arg = arg, evals = htmlwidgets:::JSEvals(arg))
+        })
       )
     )
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -202,9 +202,8 @@ invokeRemote <- function(map, method, args = list()) {
       list(
         dependencies = lapply(deps, shiny::createWebDependency),
         method = method,
-        args = lapply(args, function(arg) {
-          list(value = arg, evals = htmlwidgets::JSEvals(arg))
-        })
+        args = args,
+        evals = htmlwidgets::JSEvals(args)
       )
     )
   )

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -833,6 +833,18 @@ _htmlwidgets2["default"].widget({
   }
 });
 
+function unpackArgs(arg) {
+  if (!arg.hasOwnProperty("arg") && !arg.hasOwnProperty("evals")) {
+    throw new Error("Malformed argument; .arg and .evals expected");
+  }
+
+  for (var i = 0; i < arg.evals.length; i++) {
+    window.HTMLWidgets.evaluateStringMember(arg.arg, arg.evals[i]);
+  }
+
+  return arg.arg;
+}
+
 if (_htmlwidgets2["default"].shinyMode) {
   _shiny2["default"].addCustomMessageHandler("leaflet-calls", function (data) {
     var id = data.id;
@@ -846,12 +858,13 @@ if (_htmlwidgets2["default"].shinyMode) {
 
     for (var i = 0; i < data.calls.length; i++) {
       var call = data.calls[i];
+      var args = call.args.map(unpackArgs);
 
       if (call.dependencies) {
         _shiny2["default"].renderDependencies(call.dependencies);
       }
 
-      if (methods[call.method]) methods[call.method].apply(map, call.args);else (0, _util.log)("Unknown method " + call.method);
+      if (methods[call.method]) methods[call.method].apply(map, args);else (0, _util.log)("Unknown method " + call.method);
     }
   });
 }

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -839,10 +839,10 @@ function unpackArgs(arg) {
   }
 
   for (var i = 0; i < arg.evals.length; i++) {
-    window.HTMLWidgets.evaluateStringMember(arg.arg, arg.evals[i]);
+    window.HTMLWidgets.evaluateStringMember(arg.value, arg.evals[i]);
   }
 
-  return arg.arg;
+  return arg.value;
 }
 
 if (_htmlwidgets2["default"].shinyMode) {

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -833,18 +833,6 @@ _htmlwidgets2["default"].widget({
   }
 });
 
-function unpackArgs(arg) {
-  if (!Object.prototype.hasOwnProperty.call(arg, "value") || !Object.prototype.hasOwnProperty.call(arg, "evals")) {
-    throw new Error("Malformed argument; .value and .evals expected");
-  }
-
-  for (var i = 0; i < arg.evals.length; i++) {
-    window.HTMLWidgets.evaluateStringMember(arg.value, arg.evals[i]);
-  }
-
-  return arg.value;
-}
-
 if (_htmlwidgets2["default"].shinyMode) {
   _shiny2["default"].addCustomMessageHandler("leaflet-calls", function (data) {
     var id = data.id;
@@ -858,7 +846,11 @@ if (_htmlwidgets2["default"].shinyMode) {
 
     for (var i = 0; i < data.calls.length; i++) {
       var call = data.calls[i];
-      var args = call.args.map(unpackArgs);
+      var args = call.args;
+
+      for (var _i = 0; _i < call.evals.length; _i++) {
+        window.HTMLWidgets.evaluateStringMember(args, call.evals[_i]);
+      }
 
       if (call.dependencies) {
         _shiny2["default"].renderDependencies(call.dependencies);

--- a/inst/htmlwidgets/leaflet.js
+++ b/inst/htmlwidgets/leaflet.js
@@ -834,8 +834,8 @@ _htmlwidgets2["default"].widget({
 });
 
 function unpackArgs(arg) {
-  if (!arg.hasOwnProperty("arg") && !arg.hasOwnProperty("evals")) {
-    throw new Error("Malformed argument; .arg and .evals expected");
+  if (!Object.prototype.hasOwnProperty.call(arg, "value") || !Object.prototype.hasOwnProperty.call(arg, "evals")) {
+    throw new Error("Malformed argument; .value and .evals expected");
   }
 
   for (var i = 0; i < arg.evals.length; i++) {

--- a/javascript/src/index.js
+++ b/javascript/src/index.js
@@ -280,6 +280,16 @@ HTMLWidgets.widget({
   }
 });
 
+function unpackArgs(arg) {
+  if (!arg.hasOwnProperty("arg") && !arg.hasOwnProperty("evals")) {
+    throw new Error("Malformed argument; .arg and .evals expected");
+  }
+  for (let i = 0; i < arg.evals.length; i++) {
+    window.HTMLWidgets.evaluateStringMember(arg.arg, arg.evals[i]);
+  }
+  return arg.arg;
+}
+
 if (HTMLWidgets.shinyMode) {
   Shiny.addCustomMessageHandler("leaflet-calls", function(data) {
     let id = data.id;
@@ -292,11 +302,12 @@ if (HTMLWidgets.shinyMode) {
 
     for (let i = 0; i < data.calls.length; i++) {
       let call = data.calls[i];
+      let args = call.args.map(unpackArgs);
       if (call.dependencies) {
         Shiny.renderDependencies(call.dependencies);
       }
       if (methods[call.method])
-        methods[call.method].apply(map, call.args);
+        methods[call.method].apply(map, args);
       else
         log("Unknown method " + call.method);
     }

--- a/javascript/src/index.js
+++ b/javascript/src/index.js
@@ -285,9 +285,9 @@ function unpackArgs(arg) {
     throw new Error("Malformed argument; .arg and .evals expected");
   }
   for (let i = 0; i < arg.evals.length; i++) {
-    window.HTMLWidgets.evaluateStringMember(arg.arg, arg.evals[i]);
+    window.HTMLWidgets.evaluateStringMember(arg.value, arg.evals[i]);
   }
-  return arg.arg;
+  return arg.value;
 }
 
 if (HTMLWidgets.shinyMode) {

--- a/javascript/src/index.js
+++ b/javascript/src/index.js
@@ -281,8 +281,8 @@ HTMLWidgets.widget({
 });
 
 function unpackArgs(arg) {
-  if (!arg.hasOwnProperty("arg") && !arg.hasOwnProperty("evals")) {
-    throw new Error("Malformed argument; .arg and .evals expected");
+  if (!Object.prototype.hasOwnProperty.call(arg, "value") || !Object.prototype.hasOwnProperty.call(arg, "evals")) {
+    throw new Error("Malformed argument; .value and .evals expected");
   }
   for (let i = 0; i < arg.evals.length; i++) {
     window.HTMLWidgets.evaluateStringMember(arg.value, arg.evals[i]);

--- a/javascript/src/index.js
+++ b/javascript/src/index.js
@@ -280,16 +280,6 @@ HTMLWidgets.widget({
   }
 });
 
-function unpackArgs(arg) {
-  if (!Object.prototype.hasOwnProperty.call(arg, "value") || !Object.prototype.hasOwnProperty.call(arg, "evals")) {
-    throw new Error("Malformed argument; .value and .evals expected");
-  }
-  for (let i = 0; i < arg.evals.length; i++) {
-    window.HTMLWidgets.evaluateStringMember(arg.value, arg.evals[i]);
-  }
-  return arg.value;
-}
-
 if (HTMLWidgets.shinyMode) {
   Shiny.addCustomMessageHandler("leaflet-calls", function(data) {
     let id = data.id;
@@ -302,7 +292,10 @@ if (HTMLWidgets.shinyMode) {
 
     for (let i = 0; i < data.calls.length; i++) {
       let call = data.calls[i];
-      let args = call.args.map(unpackArgs);
+      let args = call.args;
+      for (let i = 0; i < call.evals.length; i++) {
+        window.HTMLWidgets.evaluateStringMember(args, call.evals[i]);
+      }
       if (call.dependencies) {
         Shiny.renderDependencies(call.dependencies);
       }

--- a/tests/testthat/_snaps/remote.md
+++ b/tests/testthat/_snaps/remote.md
@@ -1,0 +1,52 @@
+# mockSession tests
+
+    [[1]]
+    [[1]]$type
+    [1] "leaflet-calls"
+    
+    [[1]]$message
+    {"id":"map","calls":[{"dependencies":[],"method":"addPolygons","args":[[[[{"lng":[1,2,3,4,5],"lat":[1,2,3,4,5]}]]],null,null,{"interactive":true,"className":"","stroke":true,"color":"#03F","weight":5,"opacity":0.5,"fill":true,"fillColor":"#03F","fillOpacity":0.2,"smoothFactor":1,"noClip":false},null,null,null,{"interactive":false,"permanent":false,"direction":"auto","opacity":1,"offset":[0,0],"textsize":"10px","textOnly":false,"className":"","sticky":true},null],"evals":[]}]} 
+    
+    
+
+---
+
+    [[1]]
+    [[1]]$type
+    [1] "leaflet-calls"
+    
+    [[1]]$message
+    {"id":"map","calls":[{"dependencies":[],"method":"addMarkers","args":[[10,9,8,7,6,5,4,3,2,1],[10,9,8,7,6,5,4,3,2,1],null,null,null,{"interactive":true,"draggable":false,"keyboard":true,"title":"","alt":"","zIndexOffset":0,"opacity":1,"riseOnHover":false,"riseOffset":250},null,null,null,null,null,{"interactive":false,"permanent":false,"direction":"auto","opacity":1,"offset":[0,0],"textsize":"10px","textOnly":false,"className":"","sticky":true},null],"evals":[]}]} 
+    
+    
+
+---
+
+    [[1]]
+    [[1]]$type
+    [1] "leaflet-calls"
+    
+    [[1]]$message
+    {"id":"map","calls":[{"dependencies":[],"method":"clearShapes","args":[],"evals":[]}]} 
+    
+    
+    [[2]]
+    [[2]]$type
+    [1] "leaflet-calls"
+    
+    [[2]]$message
+    {"id":"map","calls":[{"dependencies":[],"method":"addMarkers","args":[[10,9,8,7,6,5,4,3,2,1],[10,9,8,7,6,5,4,3,2,1],null,null,null,{"interactive":true,"draggable":false,"keyboard":true,"title":"","alt":"","zIndexOffset":0,"opacity":1,"riseOnHover":false,"riseOffset":250},null,null,null,null,null,{"interactive":false,"permanent":false,"direction":"auto","opacity":1,"offset":[0,0],"textsize":"10px","textOnly":false,"className":"","sticky":true},null],"evals":[]}]} 
+    
+    
+
+# leafletProxy with JS()
+
+    [[1]]
+    [[1]]$type
+    [1] "leaflet-calls"
+    
+    [[1]]$message
+    {"id":"map","calls":[{"dependencies":[{"name":"leaflet-markercluster","version":"1.0.5","src":{"href":"leaflet-markercluster-1.0.5"},"meta":null,"script":["leaflet.markercluster.js","leaflet.markercluster.freezable.js","leaflet.markercluster.layersupport.js"],"stylesheet":["MarkerCluster.css","MarkerCluster.Default.css"],"head":null,"attachment":null,"package":null,"all_files":true}],"method":"addMarkers","args":[[52.37712,52.37783,52.37755],[4.905167,4.906357,4.905831],null,null,null,{"interactive":true,"draggable":false,"keyboard":true,"title":"","alt":"","zIndexOffset":0,"opacity":1,"riseOnHover":false,"riseOffset":250},null,null,{"showCoverageOnHover":true,"zoomToBoundsOnClick":true,"spiderfyOnMaxZoom":true,"removeOutsideVisibleBounds":true,"spiderLegPolylineOptions":{"weight":1.5,"color":"#222","opacity":0.5},"freezeAtZoom":false,"iconCreateFunction":"function(cluster) {console.log('Here comes cluster',cluster); return new L.DivIcon({html: '<div style=\"background-color:rgba(77,77,77,0.5)\"><span>' + cluster.getChildCount() + '<\/div><span>',className: 'marker-cluster'});}"},null,null,{"interactive":false,"permanent":false,"direction":"auto","opacity":1,"offset":[0,0],"textsize":"10px","textOnly":false,"className":"","sticky":true},null],"evals":["8.iconCreateFunction"]}]} 
+    
+    
+

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -152,8 +152,7 @@ test_that("mockSession tests", {
 
   mockSession$.flush()
   # nolint start
-  expected <- list(structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addPolygons\",\"args\":[[[[{\"lng\":[1,2,3,4,5],\"lat\":[1,2,3,4,5]}]]],null,null,{\"interactive\":true,\"className\":\"\",\"stroke\":true,\"color\":\"#03F\",\"weight\":5,\"opacity\":0.5,\"fill\":true,\"fillColor\":\"#03F\",\"fillOpacity\":0.2,\"smoothFactor\":1,\"noClip\":false},null,null,null,{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},null]}]}", class = "json")), .Names = c("type",
-  "message")))
+  expected <- list(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addPolygons\",\"args\":[{\"value\":[[[{\"lng\":[1,2,3,4,5],\"lat\":[1,2,3,4,5]}]]],\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":{\"interactive\":true,\"className\":\"\",\"stroke\":true,\"color\":\"#03F\",\"weight\":5,\"opacity\":0.5,\"fill\":true,\"fillColor\":\"#03F\",\"fillOpacity\":0.2,\"smoothFactor\":1,\"noClip\":false},\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},\"evals\":[]},{\"value\":null,\"evals\":[]}]}]}", class = "json")))
   # nolint end
 
   # dput(mockSession$.calls)
@@ -170,8 +169,7 @@ test_that("mockSession tests", {
   )
   # Check that addMarkers() takes effect immediately, no flush required
   remote2 %>% addMarkers()
-  expected2 <- list(structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addMarkers\",\"args\":[[10,9,8,7,6,5,4,3,2,1],[10,9,8,7,6,5,4,3,2,1],null,null,null,{\"interactive\":true,\"draggable\":false,\"keyboard\":true,\"title\":\"\",\"alt\":\"\",\"zIndexOffset\":0,\"opacity\":1,\"riseOnHover\":false,\"riseOffset\":250},null,null,null,null,null,{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},null]}]}", class = "json")), .Names = c("type",
-  "message"))) # nolint
+  expected2 <- list(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addMarkers\",\"args\":[{\"value\":[10,9,8,7,6,5,4,3,2,1],\"evals\":[]},{\"value\":[10,9,8,7,6,5,4,3,2,1],\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":{\"interactive\":true,\"draggable\":false,\"keyboard\":true,\"title\":\"\",\"alt\":\"\",\"zIndexOffset\":0,\"opacity\":1,\"riseOnHover\":false,\"riseOffset\":250},\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},\"evals\":[]},{\"value\":null,\"evals\":[]}]}]}", class = "json"))) # nolint
   # cat(deparse(mockSession$.calls), "\n")
   expect_equal(mockSession$.calls, expected2)
   # Flushing should do nothing
@@ -189,9 +187,8 @@ test_that("mockSession tests", {
   expect_equal(mockSession$.calls, list())
   mockSession$.flush()
   # nolint start
-  expected3 <- list(structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"clearShapes\",\"args\":[]}]}", class = "json")), .Names = c("type",
-  "message")), structure(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addMarkers\",\"args\":[[10,9,8,7,6,5,4,3,2,1],[10,9,8,7,6,5,4,3,2,1],null,null,null,{\"interactive\":true,\"draggable\":false,\"keyboard\":true,\"title\":\"\",\"alt\":\"\",\"zIndexOffset\":0,\"opacity\":1,\"riseOnHover\":false,\"riseOffset\":250},null,null,null,null,null,{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},null]}]}", class = "json")), .Names = c("type",
-  "message")))
+  expected3 <- list(list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"clearShapes\",\"args\":[]}]}", class = "json")),
+    list(type = "leaflet-calls", message = structure("{\"id\":\"map\",\"calls\":[{\"dependencies\":[],\"method\":\"addMarkers\",\"args\":[{\"value\":[10,9,8,7,6,5,4,3,2,1],\"evals\":[]},{\"value\":[10,9,8,7,6,5,4,3,2,1],\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":{\"interactive\":true,\"draggable\":false,\"keyboard\":true,\"title\":\"\",\"alt\":\"\",\"zIndexOffset\":0,\"opacity\":1,\"riseOnHover\":false,\"riseOffset\":250},\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":null,\"evals\":[]},{\"value\":{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},\"evals\":[]},{\"value\":null,\"evals\":[]}]}]}", class = "json")))
   # nolint end
 
   # Check that multiple calls are invoked in order


### PR DESCRIPTION
Fixes #420
Fixes #440

- [x] Make tests pass
- [x] Remove dependency on unexported function in htmlwidgets

htmlwidgets provides built-in support for the [`JS` function](https://rdrr.io/cran/htmlwidgets/man/JS.html), which lets you mark widget data string values in R to be evaluated as JS code when the widget data is deserialized in the browser. This isn't supported natively in Shiny though, so `leafletProxy` did not automatically inherit this behavior. The changes in this PR reimplement that mechanism for `leafletProxy`.

## Minimal reproducible example

From [this SO post](https://stackoverflow.com/questions/47922951/does-markercluster-work-together-with-leafletproxy-and-option-iconcreatefuncti) by @NilsOle, the following app should show the same behavior regardless of using leafletProxy or renderLeaflet. After clicking either button, zoom out to see clusters.

```r
library(shiny)
library(dplyr)
library(leaflet)

ui <- fluidPage(
  titlePanel("Hello Shiny!"),
  sidebarLayout(
    sidebarPanel(
      actionButton(inputId = "my_button1",
                   label = "Use leafletProxy()"),
      actionButton(inputId = "my_button2",
                   label = "Use renderLeaflet()")
    ),
    mainPanel(
      leafletOutput(
        outputId = "map",
        width = "100%",
        height = "300px"
      )
    )
  )
)

server <- function(input, output, session) {

  some_data <- data.frame(
    "lon"=c(4.905167,4.906357,4.905831),
    "lat"=c(52.37712,52.37783,52.37755),
    "number_var"=c(5,9,7),
    "name"=c("Jane","Harold","Mike"),
    stringsAsFactors = F
  )

  output$map <- renderLeaflet({
    return(
      leaflet(data = some_data[0,]) %>%
         addProviderTiles(providers$CartoDB.Positron) %>%
        fitBounds(
          min(some_data$lon),
          min(some_data$lat),
          max(some_data$lon),
          max(some_data$lat)
        ) %>%
        addMarkers(
          lng = ~lon,
          lat = ~lat,
          clusterOptions = markerClusterOptions(
            iconCreateFunction = JS(paste0("function(cluster) {",
                                           "return new L.DivIcon({",
                                           "html: '<div style=\"background-color:rgba(77,77,77,0.5)\"><span>' + cluster.getChildCount() + '</div><span>',",
                                           "className: 'marker-cluster'",
                                           "});",
                                           "}"))



          )
        )
    )
  })

  observeEvent(input$my_button1,{
      leafletProxy(mapId = "map",
                   session = session,
                   data = some_data) %>%
        addProviderTiles(providers$CartoDB.Positron) %>%
        clearMarkerClusters() %>%
        clearMarkers() %>%
        fitBounds(
          min(some_data$lon),
          min(some_data$lat),
          max(some_data$lon),
          max(some_data$lat)
        ) %>%
        addMarkers(
          lng = ~lon,
          lat = ~lat,
          clusterOptions = markerClusterOptions(
            iconCreateFunction = JS(paste0("function(cluster) {",
                                           "console.log('Here comes cluster',cluster); ",
                                           "return new L.DivIcon({",
                                           "html: '<div style=\"background-color:rgba(77,77,77,0.5)\"><span>' + cluster.getChildCount() + '</div><span>',",
                                           "className: 'marker-cluster'",
                                           "});",
                                           "}"))
          )
        )
  })

  observeEvent(input$my_button2,{
    output$map <- renderLeaflet({

      leaflet(data = some_data) %>%
        addProviderTiles(providers$CartoDB.Positron) %>%
        fitBounds(
          min(some_data$lon),
          min(some_data$lat),
          max(some_data$lon),
          max(some_data$lat)
        ) %>%
        addMarkers(
          lng = ~lon,
          lat = ~lat,
          clusterOptions = markerClusterOptions(
            iconCreateFunction = JS(paste0("function(cluster) {",
                                           "console.log('Here comes cluster',cluster); ",
                                           "return new L.DivIcon({",
                                           "html: '<div style=\"background-color:rgba(77,77,77,0.5)\"><span>' + cluster.getChildCount() + '</div><span>',",
                                           "className: 'marker-cluster'",
                                           "});",
                                           "}"))
          )
        )
    })
  })
}

shinyApp(ui = ui, server = server)
```

PR task list:
- [x] Update NEWS
- [x] Add tests (where appropriate)
  - R code tests: `tests/testthat/`
  - Visual tests: `R/zzz_viztest.R`
- [x] Update documentation with `devtools::document()`
