### PR TITLE
Use default linux distribution on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: r
 sudo: required
 cache: packages
-dist: trusty
 
 before_install:
   - sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable --yes


### PR DESCRIPTION
Currently build are in error [because ](https://travis-ci.com/github/rstudio/leaflet/jobs/421934604#L400)

> dist: trusty is no longer supported for language: r

Use default Ubuntu 16 (Xenial)

Or use Ubuntu 18 (bionic) or Ubuntu 20 (Focal) 

https://docs.travis-ci.com/user/reference/linux

Your call- don't know if leaflet as any constraint.