### PR TITLE
Patch leaflet.css with missing rule about <img> in pane

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@ FEATURES
 BUG FIXES and IMPROVEMENTS
 * Enable JS function literals (wrapped in `htmlwidgets::JS()`) to be included in arguments to methods invoked on `leafletProxy` objects. (JS function literals could already be included with methods invoked on `leaflet` objects, so this change just brings `leafletProxy` to parity.) (#420)
 
-
+* Add missing CSS rule to show `<img>` in right-pane and left-pane (rstudio/rmarkdown/issues#1949).
 
 leaflet 2.0.4.1
 --------------------------------------------------------------------------------

--- a/inst/htmlwidgets/lib/rstudio_leaflet/rstudio_leaflet.css
+++ b/inst/htmlwidgets/lib/rstudio_leaflet/rstudio_leaflet.css
@@ -30,3 +30,12 @@
 .leaflet-map-pane {
   z-index: auto;
 }
+
+/* Add missing rule from leaflet for img.
+This complete existing leaflet.css.
+Fix for https://github.com/rstudio/rmarkdown/issues/1949 */
+.leaflet-container .leaflet-right-pane img,
+.leaflet-container .leaflet-left-pane img {
+	max-width: none !important;
+	max-height: none !important;
+}


### PR DESCRIPTION
This PR follows the investigation and closes rstudio/rmarkdown#1949. 

Some CSS rules seems to be missing in `leaflet.css` and we add them in our CSS file. 

Issue was `<img>` in left or right pane not showing as it should because a `max-width` was set by R Markdown somewhere. leafletJS has specific rule to override such rule https://github.com/Leaflet/Leaflet/blob/e9bc85952d955347bbfd0a2d7909fdc51f08a48a/dist/leaflet.css#L52-L61

See details in https://github.com/rstudio/rmarkdown/issues/1949#issuecomment-1006706451 for more context. 

