### PR TITLE
Fix failing CRAN tests

### DIFF
--- a/inst/examples/normalize.R
+++ b/inst/examples/normalize.R
@@ -72,6 +72,7 @@ Sr3 <- Polygon(cbind(c(4, 4, 5, 10, 4), c(5, 3, 2, 5, 5)))
 Sr4 <- Polygon(cbind(c(5, 6, 6, 5, 5), c(4, 4, 3, 3, 4)), hole = TRUE)
 Srs1 <- Polygons(list(Sr1), "s1")
 Srs2 <- Polygons(list(Sr2), "s2")
+# Leaflet will automatically add comment about the hole from Sr4
 Srs3 <- Polygons(list(Sr4, Sr3), "s3/4")
 SpP <- SpatialPolygons(list(Srs1, Srs2, Srs3), 1:3)
 

--- a/tests/testthat/test-normalize-2.R
+++ b/tests/testthat/test-normalize-2.R
@@ -15,7 +15,6 @@ test_that("normalize", {
   ### polygons --------------------------------------------------------------
 
   pgontest <- function(x) {
-    cat(class(x), "\n")
     leaflet(x) %>% addTiles() %>% addPolygons()
   }
 
@@ -39,7 +38,6 @@ test_that("normalize", {
   lindata <- st_as_sf(atlStorms2005)
 
   plinetest <- function(x) {
-    cat(class(x), "\n")
     leaflet(x) %>% addTiles() %>% addPolylines()
   }
 

--- a/tests/testthat/test-normalize-2.R
+++ b/tests/testthat/test-normalize-2.R
@@ -88,7 +88,11 @@ test_that("normalize", {
       lats <- rev(lats)
     }
 
-    type(cbind(lng = lngs, lat = lats))
+    if ("hole" %in% names(formals(type))) {
+      type(cbind(lng = lngs, lat = lats), hole = hole)
+    } else {
+      type(cbind(lng = lngs, lat = lats))
+    }
   }
 
   spolys <- SpatialPolygons(list(

--- a/tests/testthat/test-normalize-2.R
+++ b/tests/testthat/test-normalize-2.R
@@ -95,7 +95,7 @@ test_that("normalize", {
     }
   }
 
-  spolys <- SpatialPolygons(list(
+  polys <-
     Polygons(list(
       create_square(),
       create_square(, 5, 5),
@@ -103,6 +103,10 @@ test_that("normalize", {
       create_square(1, 5, 5, hole = TRUE),
       create_square(0.4, 4.25, 4.25, hole = TRUE)
     ), "A")
+  comment(polys) <- rgeos::createPolygonsComment(polys)
+
+  spolys <- SpatialPolygons(list(
+    polys
   ))
   stspolys <- st_as_sf(spolys)
   (l101 <- leaflet(spolys) %>% addPolygons())


### PR DESCRIPTION
Fixes #772 

Inspiration from 
https://rgeos.r-forge.r-project.org/reference/comment-functions.html#details
and the example where it set `comment(pls) = createPolygonsComment(pls)`

By setting the comments before it was converted via `st_as_sf()`, it fixed the tests.

Tests started to fail with `sf` v `1.0-6`