### PR TITLE
`ordered = TRUE` for `colorFactor` fixes #800

### DIFF
--- a/R/colors.R
+++ b/R/colors.R
@@ -208,7 +208,7 @@ getLevels <- function(domain, x, lvls, ordered) {
 #'   factor, treat it as already in the correct order
 #' @rdname colorNumeric
 #' @export
-colorFactor <- function(palette, domain, levels = NULL, ordered = FALSE,
+colorFactor <- function(palette, domain, levels = NULL, ordered = TRUE,
   na.color = "#808080", alpha = FALSE, reverse = FALSE) {
 
   # domain usually needs to be explicitly provided (even if NULL) but not if


### PR DESCRIPTION
When the code is written as `pal <- colorFactor(c("navy", "red"), domain = c("ship", "pirate"))`, then it is highly likely that the user's intention is to have `navy` for `ship`, and `red` for `pirate`.
Therefore it makes more sense that `colorFactor` should assume that the `domain` vector is already ordered (`ordered = TRUE`) unless stated otherwise.

PR task list:
- [x] Update NEWS (#800)
- [ ] ~~Add tests (where appropriate)~~
  - R code tests: `tests/testthat/`
  - Visual tests: `R/zzz_viztest.R`
- [ ] Update documentation with `devtools::document()`
