### PR TITLE
Added option to addProviderTiles() for user to specify .js file location

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: leaflet
 Type: Package
 Title: Create Interactive Web Maps with the JavaScript 'Leaflet' Library
-Version: 2.1.1
+Version: 2.1.2
 Authors@R: c(
       person("Joe", "Cheng", email = "joe@rstudio.com", role = c("aut", "cre")),
       person("Bhaskar", "Karambelkar", role = c("aut")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+leaflet 2.1.2
+--------------------------------------------------------------------------------
+
+BUG FIXES and IMPROVEMENTS
+* `addProviderTiles` updated to allow the user to specify where to save the .js file. This was needed because the default temp file does not surive cached rebuilds when using when using Quarto.
+
 leaflet 2.1.1
 --------------------------------------------------------------------------------
 

--- a/R/plugin-providers.R
+++ b/R/plugin-providers.R
@@ -1,6 +1,6 @@
-leafletProviderDependencies <- function() {
+leafletProviderDependencies <- function(dependencyLocation=tempdir()) {
   list(
-    get_providers_html_dependency(),
+    get_providers_html_dependency(dependencyLocation=dependencyLocation),
     htmltools::htmlDependency(
       "leaflet-providers-plugin",
       get_package_version("leaflet"),
@@ -23,6 +23,7 @@ leafletProviderDependencies <- function() {
 #'   Human-friendly group names are permitted--they need not be short,
 #'   identifier-style names.
 #' @param options tile options
+#' @param dependencyLocation Location to store providers JS file
 #' @return modified map object
 #'
 #' @examples
@@ -36,9 +37,10 @@ addProviderTiles <- function(
   provider,
   layerId = NULL,
   group = NULL,
-  options = providerTileOptions()
+  options = providerTileOptions(),
+  dependencyLocation=tempdir()
 ) {
-  map$dependencies <- c(map$dependencies, leafletProviderDependencies())
+  map$dependencies <- c(map$dependencies, leafletProviderDependencies(dependencyLocation=dependencyLocation))
   invokeMethod(map, getMapData(map), "addProviderTiles",
     provider, layerId, group, options)
 }
@@ -89,19 +91,19 @@ NULL
 # Active binding added in zzz.R
 "providers.src"
 
-get_providers_html_dependency <- function() {
-  tmpfile <- file.path(tempdir(), paste0("leaflet-providers_", providers.version_num, ".js"))
+get_providers_html_dependency <- function(dependencyLocation=tempdir()) {
+  depfile <- file.path(dependencyLocation, paste0("leaflet-providers_", providers.version_num, ".js"))
 
-  if (!file.exists(tmpfile)) {
+  if (!file.exists(depfile)) {
     src <- providers.src
-    writeLines(src, tmpfile)
+    writeLines(src, depfile)
   }
 
   htmltools::htmlDependency(
     "leaflet-providers",
     providers.version_num,
-    src = dirname(tmpfile),
-    script = basename(tmpfile),
+    src = dirname(depfile),
+    script = basename(depfile),
     all_files = FALSE
   )
 }

--- a/man/addProviderTiles.Rd
+++ b/man/addProviderTiles.Rd
@@ -10,7 +10,8 @@ addProviderTiles(
   provider,
   layerId = NULL,
   group = NULL,
-  options = providerTileOptions()
+  options = providerTileOptions(),
+  dependencyLocation = tempdir()
 )
 
 providerTileOptions(
@@ -38,6 +39,8 @@ Human-friendly group names are permitted--they need not be short,
 identifier-style names.}
 
 \item{options}{tile options}
+
+\item{dependencyLocation}{Location to store providers JS file}
 
 \item{errorTileUrl, noWrap, opacity, zIndex, updateWhenIdle, detectRetina}{the tile layer options; see
 \url{https://leafletjs.com/reference-1.3.4.html#tilelayer}}


### PR DESCRIPTION
When calling `addProviderTiles`, JavaScript is written to a temp file. This does not persist when using Quarto (but it has in the past with regular rmarkdown). So I added an option in `addProviderTile` (along with subsequently called functions) for the user to specify a location to write that JavaScript file. This fixed the problem for a presentation I am working on that has many called to `addProviderTiles`.

## Minimal reproducible example

```r
library(leaflet)

# this is the inst folder for leaflet
pop <- sf::read_sf('inst/csv/uspop2000.csv') |> 
  sf::st_as_sf(coords=c('Long', 'Lat'), remove=FALSE)

leaflet() |> 
  addProviderTiles('CartoDB.Voyager', dependencyLocation='~') |> 
  addCircles(data=pop)
```

PR task list:
- [X ] Update NEWS
- [ ] Add tests (where appropriate)
  - R code tests: `tests/testthat/`
  - Visual tests: `R/zzz_viztest.R`
- [ X] Update documentation with `devtools::document()`
