### PR TITLE
leafletOutput()'s width and height now default to NULL

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -18,7 +18,7 @@
 #' )
 #'
 #' \donttest{if (interactive()) app}
-leafletOutput <- function(outputId, width = "100%", height = 400) {
+leafletOutput <- function(outputId, width = NULL, height = NULL) {
   htmltools::attachDependencies(
     htmlwidgets::shinyWidgetOutput(outputId, "leaflet", width, height, "leaflet"),
     leafletBindingDependencies(),

--- a/inst/htmlwidgets/lib/rstudio_leaflet/rstudio_leaflet.css
+++ b/inst/htmlwidgets/lib/rstudio_leaflet/rstudio_leaflet.css
@@ -39,3 +39,8 @@ Fix for https://github.com/rstudio/rmarkdown/issues/1949 */
 	max-width: none !important;
 	max-height: none !important;
 }
+
+.leaflet.html-widget {
+  height: 400px;
+  width: 100%;
+}

--- a/man/map-shiny.Rd
+++ b/man/map-shiny.Rd
@@ -5,7 +5,7 @@
 \alias{renderLeaflet}
 \title{Wrapper functions for using \pkg{leaflet} in \pkg{shiny}}
 \usage{
-leafletOutput(outputId, width = "100\%", height = 400)
+leafletOutput(outputId, width = NULL, height = NULL)
 
 renderLeaflet(expr, env = parent.frame(), quoted = FALSE)
 }


### PR DESCRIPTION
In anticipation of https://github.com/ramnathv/htmlwidgets/pull/437 (and https://github.com/rstudio/bslib/pull/452)