### PR TITLE
Stop using the internal function markdown:::.b64EncodeFile()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,13 +34,12 @@ URL: https://rstudio.github.io/leaflet/
 BugReports: https://github.com/rstudio/leaflet/issues
 Depends: R (>= 3.1.0)
 Imports:
-    base64enc,
+    xfun,
     crosstalk,
     htmlwidgets (>= 1.5.4),
     htmltools,
     jquerylib,
     magrittr,
-    markdown,
     methods,
     png,
     RColorBrewer,

--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ BUG FIXES and IMPROVEMENTS
 
 * `leafletOutput()`'s `height` and `width` now defaults to `NULL`, allowing it have more flexible default sizing behavior, which will be primarily useful in combination with `{bslib}`'s new `card()` API. (#2192)
 
+* Use `xfun::base64_uri()` for base64 encoding instead of **markdown** and **base64enc**. (#823)
 
 leaflet 2.1.1
 --------------------------------------------------------------------------------

--- a/R/layers.R
+++ b/R/layers.R
@@ -343,8 +343,7 @@ addRasterImage_RasterLayer <- function(
       maxBytes, " bytes"
     )
   }
-  encoded <- base64enc::base64encode(pngData)
-  uri <- paste0("data:image/png;base64,", encoded)
+  uri <- xfun::base64_uri(pngData, "image/png")
 
   latlng <- list(
     list(raster::ymax(bounds), raster::xmin(bounds)),
@@ -423,8 +422,7 @@ addRasterImage_SpatRaster <- function(
       maxBytes, " bytes"
     )
   }
-  encoded <- base64enc::base64encode(pngData)
-  uri <- paste0("data:image/png;base64,", encoded)
+  uri <- xfun::base64_uri(pngData, "image/png")
 
   latlng <- list(
     list(terra::ymax(bounds), terra::xmin(bounds)),
@@ -1013,12 +1011,9 @@ b64EncodePackedIcons <- function(packedIcons) {
   if (is.null(packedIcons))
     return(packedIcons)
 
-  # TODO: remove this when we've got our own encoding function
-  markdown::markdownToHTML
-  image_uri <- getFromNamespace(".b64EncodeFile", "markdown")
   packedIcons$data <- sapply(packedIcons$data, function(icon) {
     if (is.character(icon) && file.exists(icon)) {
-      image_uri(icon)
+      xfun::base64_uri(icon)
     } else {
       icon
     }


### PR DESCRIPTION
I plan to remove this function from **markdown** package in the near future. It'll be great if you can make a new CRAN release of **leaflet** in a couple of months. Thanks!

BTW, **xfun** has zero hard dependencies, so this PR has reduced the number of hard dependencies by one (added one and removed two).

PR task list:

- [x] Update NEWS
- [ ] Add tests (where appropriate)
  - R code tests: `tests/testthat/`
  - Visual tests: `R/zzz_viztest.R`
- [ ] Update documentation with `devtools::document()`
