### PR TITLE
Revert #822

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,8 +6,6 @@ BUG FIXES and IMPROVEMENTS
 
 * Update jQuery to utilize `{jquerylib}`. (#817)
 
-* `leafletOutput()`'s `height` and `width` now defaults to `NULL`, allowing it have more flexible default sizing behavior, which will be primarily useful in combination with `{bslib}`'s new `card()` API. (#2192)
-
 * Use `xfun::base64_uri()` for base64 encoding instead of **markdown** and **base64enc**. (#823)
 
 leaflet 2.1.1

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -18,7 +18,7 @@
 #' )
 #'
 #' \donttest{if (interactive()) app}
-leafletOutput <- function(outputId, width = NULL, height = NULL) {
+leafletOutput <- function(outputId, width = "100%", height = 400) {
   htmltools::attachDependencies(
     htmlwidgets::shinyWidgetOutput(outputId, "leaflet", width, height, "leaflet"),
     leafletBindingDependencies(),

--- a/inst/htmlwidgets/lib/rstudio_leaflet/rstudio_leaflet.css
+++ b/inst/htmlwidgets/lib/rstudio_leaflet/rstudio_leaflet.css
@@ -39,8 +39,3 @@ Fix for https://github.com/rstudio/rmarkdown/issues/1949 */
 	max-width: none !important;
 	max-height: none !important;
 }
-
-.leaflet.html-widget {
-  height: 400px;
-  width: 100%;
-}

--- a/man/map-shiny.Rd
+++ b/man/map-shiny.Rd
@@ -5,7 +5,7 @@
 \alias{renderLeaflet}
 \title{Wrapper functions for using \pkg{leaflet} in \pkg{shiny}}
 \usage{
-leafletOutput(outputId, width = NULL, height = NULL)
+leafletOutput(outputId, width = "100\%", height = 400)
 
 renderLeaflet(expr, env = parent.frame(), quoted = FALSE)
 }


### PR DESCRIPTION
Recent changes made in https://github.com/ramnathv/htmlwidgets/pull/442 makes #822 unnecessary to fill by default. And since I can't think of a situation where you'd actually want `fill = FALSE` for leaflet, let's not add a `fill` argument to `leafletOutput()` until we know we need it. 