### PR TITLE
Include leaflet-specific class in all leafletfix selectors

### DIFF
--- a/inst/htmlwidgets/lib/leafletfix/leafletfix.css
+++ b/inst/htmlwidgets/lib/leafletfix/leafletfix.css
@@ -5,7 +5,7 @@ img.leaflet-tile {
   border-radius: 0;
   border: none;
 }
-.info {
+.leaflet .info {
   padding: 6px 8px;
   font: 14px/16px Arial, Helvetica, sans-serif;
   background: white;
@@ -13,17 +13,17 @@ img.leaflet-tile {
   box-shadow: 0 0 15px rgba(0,0,0,0.2);
   border-radius: 5px;
 }
-.legend {
+.leaflet .legend {
   line-height: 18px;
   color: #555;
 }
-.legend svg text {
+.leaflet .legend svg text {
   fill: #555;
 }
-.legend svg line {
+.leaflet .legend svg line {
   stroke: #555;
 }
-.legend i {
+.leaflet .legend i {
   width: 18px;
   height: 18px;
   margin-right: 4px;


### PR DESCRIPTION
Fixes #858 

This is a small tweak to `leafletfix.css` to include the `.leaflet` class in all selectors. The specific issue is that a bare `.info` class is very likely to result in conflicts with selectors in other projects. Similarly `.legend` alone is likely to have the same problem.

This does increase the class specificity by one class point, and it's possible that some users will need to update custom CSS rules. I didn't find anything in [leaflet.css](https://github.com/rstudio/leaflet/blob/fix/858-leafletfix-css-specificity/inst/htmlwidgets/lib/leaflet/leaflet.css) that would conflict with these rules.

I'm also fairly confident that `.leaflet` is the right class to key off of, but `.leaflet-container` also looked reasonable.