### PR TITLE
Call `terra::has.RGB()` with namespace

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,6 +16,8 @@ BUG FIXES and IMPROVEMENTS
 
 - Respect option scrollWheelZoom=FALSE. (#827)
 
+- Fixed #866: Correctly call `terra::has.RGB()` in `addRasterImage()` for a `SpatRaster` object. (#869)
+
 ## leaflet 2.1.2
 
 BUG FIXES and IMPROVEMENTS

--- a/R/layers.R
+++ b/R/layers.R
@@ -463,9 +463,14 @@ addRasterImage_SpatRaster <- function(
   maxBytes = 4 * 1024 * 1024,
   data = getMapData(map)
 ) {
+  if (!is_installed("terra", "1.6-3")) { # for terra::has.RGB()
+    stop(
+      "`addRasterImage()` for SpatRaster objects requires {terra} 1.6-3 or higher",
+      call. = FALSE
+    )
+  }
 
-  # terra 1.5-50 has terra::has.RGB()
-  if (has.RGB(x)) {
+  if (terra::has.RGB(x)) {
     # RGB(A) channels to color table
     x <- terra::colorize(x, "col")
   } else if (terra::nlyr(x) > 1) {

--- a/R/layers.R
+++ b/R/layers.R
@@ -325,11 +325,11 @@ addRasterImage <- function(
 addRasterLegend <- function(map, x, layer = 1, ...) {
   stopifnot(inherits(x, "SpatRaster"))
   stopifnot(length(layer) == 1 && layer > 0 && layer <= terra::nlyr(x))
-  
-## might as well do this here and only once. Subsetting would otherwise have been necessary in 
+
+## might as well do this here and only once. Subsetting would otherwise have been necessary in
 ##  color_info <- base::subset(color_info, value %in% terra::values(x))
   x <- x[[layer]]
-  
+
   # Retrieve the color table from the layer. If one doesn't exist, that means
   # the raster was colored some other way, like using colorFactor or something,
   # and the regular addLegend() is designed for those cases.
@@ -348,13 +348,13 @@ addRasterLegend <- function(map, x, layer = 1, ...) {
   lvls <- terra::levels(x)[[1]]
 
   # Drop values that aren't part of the layer
-## unlike "values",  "unique" is memory-safe; it does not load all values 
+## unlike "values",  "unique" is memory-safe; it does not load all values
 ## into memory if the raster is large. So instead of:
 
 #  color_info <- base::subset(color_info, value %in% terra::values(x))
 
 ## remove the levels to get the raw cell values
-  levels(x) <- NULL  
+  levels(x) <- NULL
   color_info <- base::subset(color_info, value %in% terra::unique(x)[[1]])
 
   res <- if (is.data.frame(lvls)) {

--- a/R/staticimports.R
+++ b/R/staticimports.R
@@ -26,9 +26,19 @@ get_package_version <- function(pkg) {
 
 is_installed <- function(pkg, version = NULL) {
   installed <- isNamespaceLoaded(pkg) || nzchar(system_file_cached(package = pkg))
+
   if (is.null(version)) {
     return(installed)
   }
+
+  if (!is.character(version) && !inherits(version, "numeric_version")) {
+    # Avoid https://bugs.r-project.org/show_bug.cgi?id=18548
+    alert <- if (identical(Sys.getenv("TESTTHAT"), "true")) stop else warning
+    alert("`version` must be a character string or a `package_version` or `numeric_version` object.")
+
+    version <- numeric_version(sprintf("%0.9g", version))
+  }
+
   installed && isTRUE(get_package_version(pkg) >= version)
 }
 


### PR DESCRIPTION
Fixes #866

Adds the namespace prefix for `terra::has.RGB()` which would cause errors if the user hadn't already attached `terra`.

I also updated staticimports and added a check in `addRasterLegend_SpatRaster()` to ensure terra >= 1.6-3 is installed.