### PR TITLE
Fix rcmdcheck warnings

### DIFF
--- a/R/layers.R
+++ b/R/layers.R
@@ -357,7 +357,8 @@ addRasterLegend <- function(map, x, layer = 1, ...) {
   #
   # remove the levels to get the raw cell values
   levels(x) <- NULL
-  color_info <- base::subset(color_info, value %in% terra::unique(x)[[1]])
+  value_in_layer <- color_info$value %in% terra::unique(x)[[1]]
+  color_info <- color_info[value_in_layer & !is.na(value_in_layer), ]
 
   res <- if (is.data.frame(lvls)) {
     # Use the labels from levels(x), and look up the matching colors.

--- a/R/normalize-terra.R
+++ b/R/normalize-terra.R
@@ -54,17 +54,20 @@ assure_crs_terra <- function(x) {
   stopifnot(is_installed("terra"))
 
   prj <- raster::crs(x, proj = TRUE)
+
+  if (is.na(prj) || (prj == "")) {
+    # Don't have enough information to check
+    warning("SpatVector layer is not long-lat data", call. = FALSE)
+    return(x)
+  }
+
   if (terra::is.lonlat(x, perhaps = TRUE, warn = FALSE)) {
     if (!grepl("+datum=WGS84", prj, fixed = TRUE)) {
       x <- terra::project(x, "+proj=longlat +datum=WGS84")
     }
     return(x)
   }
-  # Don't have enough information to check
-  if (is.na(prj) || (prj == "")) {
-    warning("SpatVector layer is not long-lat data", call. = FALSE)
-    return(x)
-  }
+
   terra::project(x, "+proj=longlat +datum=WGS84")
 }
 

--- a/R/normalize-terra.R
+++ b/R/normalize-terra.R
@@ -51,19 +51,21 @@ polygonData.SpatVector <- function(obj) {
 
 # helpers -----------------------------------------------------------------
 assure_crs_terra <- function(x) {
-  prj <- crs(x, proj=TRUE)
-  if (is.lonlat(x, perhaps=TRUE, warn=FALSE)) {
+  stopifnot(is_installed("terra"))
+
+  prj <- raster::crs(x, proj = TRUE)
+  if (terra::is.lonlat(x, perhaps = TRUE, warn = FALSE)) {
     if (!grepl("+datum=WGS84", prj, fixed = TRUE)) {
-	  x <- project(x, "+proj=longlat +datum=WGS84")
+      x <- terra::project(x, "+proj=longlat +datum=WGS84")
     }
-	return(x)
-  }
-  # Don't have enough information to check
-  if (is.na(crs) || (crs=="")) {
-    warning("SpatVector layer is not long-lat data", call. = FALSE)	
     return(x)
   }
-  project(x, "+proj=longlat +datum=WGS84")
+  # Don't have enough information to check
+  if (is.na(prj) || (prj == "")) {
+    warning("SpatVector layer is not long-lat data", call. = FALSE)
+    return(x)
+  }
+  terra::project(x, "+proj=longlat +datum=WGS84")
 }
 
 check_crs_terra <- function(x) {


### PR DESCRIPTION
Fixes a set of warnings introduced in #808

```
❯ checking R code for possible problems ... NOTE
  addRasterLegend: no visible binding for global variable ‘value’
  assure_crs_terra: no visible global function definition for ‘crs’
  assure_crs_terra: no visible global function definition for ‘is.lonlat’
  assure_crs_terra: no visible global function definition for ‘project’
  assure_crs_terra: no visible binding for global variable ‘crs’
  Undefined global functions or variables:
    crs is.lonlat project value
```
