### PR TITLE
feat: Use stable leaflet.providers html dep if available

### DIFF
--- a/R/plugin-providers.R
+++ b/R/plugin-providers.R
@@ -89,7 +89,19 @@ NULL
 # Active binding added in zzz.R
 "providers.src"
 
+# Active binding added in zzz.R
+"providers.dep"
+
 get_providers_html_dependency <- function() {
+  if (is.null(providers.dep)) {
+    return(create_temp_providers_html_dependency())
+  }
+
+  providers.dep
+}
+
+create_temp_providers_html_dependency <- function() {
+  # for compatibility with older versions of leaflet.providers
   tmpfile <- file.path(tempdir(), paste0("leaflet-providers_", providers.version_num, ".js"))
 
   if (!file.exists(tmpfile)) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,4 +15,8 @@ leaflet_envir <- environment()
   makeActiveBinding("providers.src", function() {
     leaflet.providers::providers_loaded()$src
   }, env = leaflet_envir)
+
+  makeActiveBinding("providers.dep", function() {
+    leaflet.providers::providers_loaded()$dep
+  }, env = leaflet_envir)
 }


### PR DESCRIPTION
Fixes #732
Fixes #843
For rstudio/leaflet.providers#34

This PR pairs with https://github.com/rstudio/leaflet.providers/pull/36 to use the html dependency created by leaflet.providers, if available. 

With the latest version of leaflet.providers, leaflet will use a stable html dependency that will not change between R sessions and will, in general, be consistent in the knitr cache (excepting package updates which should break the cache anyway). 

In the presence of an older version of leaflet.providers, leaflet will still create a temporary html dependency, so this is a backwards-compatible change.

With `rstudio/leaflet.providers#36` loaded, you'll see:

```r
leaflet()  |>
  setView(lng = -71.0589, lat = 42.3601, zoom = 12) |> 
  addTiles() |> 
  addProviderTiles("Stamen.Toner") |> 
  htmltools::findDependencies() |>
  purrr::keep(\(x) x$name == "leaflet-providers")
#> [[1]]
#> List of 10
#>  $ name      : chr "leaflet-providers"
#>  $ version   : chr "2.0.0"
#>  $ src       :List of 1
#>   ..$ file: chr "/Users/garrick/work/rstudio/leaflet.providers/inst"
#>  $ meta      : NULL
#>  $ script    : chr "leaflet-providers_2.0.0.js"
#>  $ stylesheet: NULL
#>  $ head      : NULL
#>  $ attachment: NULL
#>  $ package   : NULL
#>  $ all_files : logi FALSE
#>  - attr(*, "class")= chr "html_dependency"
```

And for versions other than the bundled leaflet-providers:

```r
use_providers(get_providers("1.13.0"))

leaflet()  |>
  setView(lng = -71.0589, lat = 42.3601, zoom = 12) |> 
  addTiles() |> 
  addProviderTiles("Stamen.Toner") |> 
  htmltools::findDependencies() |>
  purrr::keep(\(x) x$name == "leaflet-providers")
#> [[1]]
#> List of 10
#>  $ name      : chr "leaflet-providers"
#>  $ version   : chr "1.13.0"
#>  $ src       :List of 1
#>   ..$ href: chr "https://unpkg.com/leaflet-providers@1.13.0"
#>  $ meta      : NULL
#>  $ script    : chr "leaflet-providers.js"
#>  $ stylesheet: NULL
#>  $ head      : NULL
#>  $ attachment: NULL
#>  $ package   : NULL
#>  $ all_files : logi FALSE
#>  - attr(*, "class")= chr "html_dependency"
```