### PR TITLE
fix: don't git clean automatically

### DIFF
--- a/scripts/git_clean.R
+++ b/scripts/git_clean.R
@@ -1,2 +1,10 @@
-# run without --dry-run
-system("git clean -xfd -e node_modules -e revdep")
+# Check files that should be cleaned (ignoring directories)
+needs_cleaned <- system("git clean -xf --dry-run")
+
+if (length(needs_cleaned)) {
+  stop(
+    "There are untracked files in the repo. Please run",
+    "`git clean -xf --dry-run` to see what will be removed. ",
+    "Add --force to force removal of untracked files."
+  )
+}


### PR DESCRIPTION
Removes a dangerous and destructive `git clean -xfd` from the doc update script.

This should really be fixed by switching to a pkgdown site, but in the meantime the update script shouldn't delete files without confirmation. The biggest problem is that `git clean -xfd` will remove directories that are gitignored, so nothing is safe really.