### PR TITLE
docs: Switch to `Stadia.Stamen____`

### DIFF
--- a/docs/basemaps.Rmd
+++ b/docs/basemaps.Rmd
@@ -22,7 +22,7 @@ Alternatively, many popular free third-party basemaps can be added using the `ad
 As a convenience, leaflet also provides a named list of all the third-party tile providers that are supported by the plugin. This enables you to use auto-completion feature of your favorite R IDE (like RStudio) and not have to remember or look up supported tile providers; just type `providers$` and choose from one of the options. You can also use `names(providers)` to view all of the options.
 
 ```{r fig.height=1.25}
-m %>% addProviderTiles(providers$Stamen.Toner)
+m %>% addProviderTiles(providers$Stadia.StamenToner)
 m %>% addProviderTiles(providers$CartoDB.Positron)
 m %>% addProviderTiles(providers$Esri.NatGeoWorldMap)
 ```
@@ -53,7 +53,7 @@ You aren't restricted to using a single basemap on a map; you can stack them by 
 
 ```{r fig.height=1.75}
 m %>% addProviderTiles(providers$MtbMap) %>%
-  addProviderTiles(providers$Stamen.TonerLines,
+  addProviderTiles(providers$Stadia.StamenTonerLines,
     options = providerTileOptions(opacity = 0.35)) %>%
-  addProviderTiles(providers$Stamen.TonerLabels)
+  addProviderTiles(providers$Stadia.StamenTonerLabels)
 ```

--- a/docs/basemaps.html
+++ b/docs/basemaps.html
@@ -317,7 +317,7 @@ RStudio) and not have to remember or look up supported tile providers;
 just type <code>providers$</code> and choose from one of the options.
 You can also use <code>names(providers)</code> to view all of the
 options.</p>
-<pre class="r"><code>m %&gt;% addProviderTiles(providers$Stamen.Toner)</code></pre>
+<pre class="r"><code>m %&gt;% addProviderTiles(providers$Stadia.StamenToner)</code></pre>
 <div class="leaflet html-widget html-fill-item-overflow-hidden html-fill-item" id="htmlwidget-92aa9ec4a26e6d2eb4c3" style="width:100%;height:120px;"></div>
 <script type="application/json" data-for="htmlwidget-92aa9ec4a26e6d2eb4c3">{
   "x": {
@@ -339,7 +339,7 @@ options.</p>
       {
         "method": "addProviderTiles",
         "args": [
-          null,
+          "Stadia.StamenToner",
           null,
           null,
           {
@@ -524,9 +524,9 @@ stack them by adding multiple tile layers. This generally only makes
 sense if the front tiles consist of semi transparent tiles, or have an
 adjusted opacity via the <code>options</code> argument.</p>
 <pre class="r"><code>m %&gt;% addProviderTiles(providers$MtbMap) %&gt;%
-  addProviderTiles(providers$Stamen.TonerLines,
+  addProviderTiles(providers$Stadia.StamenTonerLines,
     options = providerTileOptions(opacity = 0.35)) %&gt;%
-  addProviderTiles(providers$Stamen.TonerLabels)</code></pre>
+  addProviderTiles(providers$Stadia.StamenTonerLabels)</code></pre>
 <div class="leaflet html-widget html-fill-item-overflow-hidden html-fill-item" id="htmlwidget-2f386608a10ed269577b" style="width:100%;height:168px;"></div>
 <script type="application/json" data-for="htmlwidget-2f386608a10ed269577b">{
   "x": {
@@ -561,7 +561,7 @@ adjusted opacity via the <code>options</code> argument.</p>
       {
         "method": "addProviderTiles",
         "args": [
-          null,
+          "Stadia.StamenTonerLines",
           null,
           null,
           {
@@ -575,7 +575,7 @@ adjusted opacity via the <code>options</code> argument.</p>
       {
         "method": "addProviderTiles",
         "args": [
-          null,
+          "Stadia.StamenTonerLabels",
           null,
           null,
           {

--- a/docs/shiny.Rmd
+++ b/docs/shiny.Rmd
@@ -31,7 +31,7 @@ server <- function(input, output, session) {
 
   output$mymap <- renderLeaflet({
     leaflet() %>%
-      addProviderTiles(providers$Stamen.TonerLite,
+      addProviderTiles(providers$Stadia.StamenTonerLite,
         options = providerTileOptions(noWrap = TRUE)
       ) %>%
       addMarkers(data = points())

--- a/docs/shiny.html
+++ b/docs/shiny.html
@@ -264,7 +264,7 @@ server &lt;- function(input, output, session) {
 
   output$mymap &lt;- renderLeaflet({
     leaflet() %&gt;%
-      addProviderTiles(providers$Stamen.TonerLite,
+      addProviderTiles(providers$Stadia.StamenTonerLite,
         options = providerTileOptions(noWrap = TRUE)
       ) %&gt;%
       addMarkers(data = points())

--- a/docs/showhide.Rmd
+++ b/docs/showhide.Rmd
@@ -45,8 +45,8 @@ outline <- quakes[chull(quakes$long, quakes$lat),]
 map <- leaflet(quakes) %>%
   # Base groups
   addTiles(group = "OSM (default)") %>%
-  addProviderTiles(providers$Stamen.Toner, group = "Toner") %>%
-  addProviderTiles(providers$Stamen.TonerLite, group = "Toner Lite") %>%
+  addProviderTiles(providers$Stadia.StamenToner, group = "Toner") %>%
+  addProviderTiles(providers$Stadia.StamenTonerLite, group = "Toner Lite") %>%
   # Overlay groups
   addCircles(~long, ~lat, ~10^mag/5, stroke = F, group = "Quakes") %>%
   addPolygons(data = outline, lng = ~long, lat = ~lat,

--- a/docs/showhide.html
+++ b/docs/showhide.html
@@ -299,8 +299,8 @@ the visibility of groups.</p>
 map &lt;- leaflet(quakes) %&gt;%
   # Base groups
   addTiles(group = &quot;OSM (default)&quot;) %&gt;%
-  addProviderTiles(providers$Stamen.Toner, group = &quot;Toner&quot;) %&gt;%
-  addProviderTiles(providers$Stamen.TonerLite, group = &quot;Toner Lite&quot;) %&gt;%
+  addProviderTiles(providers$Stadia.StamenToner, group = &quot;Toner&quot;) %&gt;%
+  addProviderTiles(providers$Stadia.StamenTonerLite, group = &quot;Toner Lite&quot;) %&gt;%
   # Overlay groups
   addCircles(~long, ~lat, ~10^mag/5, stroke = F, group = &quot;Quakes&quot;) %&gt;%
   addPolygons(data = outline, lng = ~long, lat = ~lat,
@@ -351,7 +351,7 @@ map</code></pre>
       {
         "method": "addProviderTiles",
         "args": [
-          null,
+          "Stadia.StamenToner",
           null,
           "Toner",
           {
@@ -364,7 +364,7 @@ map</code></pre>
       {
         "method": "addProviderTiles",
         "args": [
-          null,
+          "Stadia.StamenTonerLite",
           null,
           "Toner Lite",
           {
@@ -538,7 +538,7 @@ checked by default.</p>
       {
         "method": "addProviderTiles",
         "args": [
-          null,
+          "Stadia.StamenToner",
           null,
           "Toner",
           {
@@ -551,7 +551,7 @@ checked by default.</p>
       {
         "method": "addProviderTiles",
         "args": [
-          null,
+          "Stadia.StamenTonerLite",
           null,
           "Toner Lite",
           {


### PR DESCRIPTION
Updates documentation to use latest `Stadia.Stamen____` tiles instead of `Stamen.____`.

Stamen Tiles have been migrated to Stadia (see #883) and it's not clear how accessible these will be after October 31. I think it's still worth using them in our docs as a test case; we can re-address next month.