### PR TITLE
Replace `{viridis}` dependency by `{viridisLite}`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,7 @@ Imports:
     scales (>= 1.0.0),
     sp,
     stats,
-    viridis (>= 0.5.1),
+    viridisLite,
     xfun
 Suggests:
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fixed #893: Correctly call `terra::crs()` when checking the CRS of a `SpatVector` object in `pointData()` or `polygonData()` (thanks @mkoohafkan, #894).
 
+* Replace viridis dependency by viridisLite (@olivroy, #897)
+
 # leaflet 2.2.1
 
 * When `addProviderTiles()` is used with `{leaflet.providers}` version 2.0.0 or later, the `leaflet-providers` HTML dependency produced can be correctly cached by knitr. When used with older versions of `{leaflet.providers}`, the HTML dependency uses temp files that break knitr's caching mechanism (thanks @qdread, @jaredlander; #884).

--- a/R/colors.R
+++ b/R/colors.R
@@ -332,7 +332,7 @@ toPaletteFunc.character <- function(pal, alpha, nlevels) {
       colors <- brewer_pal(pal) # Get all colors
     }
   } else if (length(pal) == 1 && pal %in% c("viridis", "magma", "inferno", "plasma")) {
-    colors <- viridis::viridis(n = 256, option = pal)
+    colors <- viridisLite::viridis(n = 256, option = pal)
   } else {
     colors <- pal
   }

--- a/inst/examples/polygon-colors.R
+++ b/inst/examples/polygon-colors.R
@@ -42,7 +42,7 @@ leaf <- leaflet(spdf)
 #'
 #' ### Quantiles
 
-qpal <- colorQuantile(rev(viridis::viridis(10)), spdf$POPDENSITY, n = 10)
+qpal <- colorQuantile(rev(viridisLite::viridis(10)), spdf$POPDENSITY, n = 10)
 
 leaf %>%
   addPolygons(weight = 1, color = "#333333", fillOpacity = 1,
@@ -55,7 +55,7 @@ leaf %>%
 #'
 #'
 #' ### Bins
-binpal <- colorBin(rev(viridis::viridis(10)), spdf$POPDENSITY, bins = 10)
+binpal <- colorBin(rev(viridisLite::viridis(10)), spdf$POPDENSITY, bins = 10)
 
 leaf %>%
   addPolygons(weight = 1, color = "#333333", fillOpacity = 1,
@@ -67,7 +67,7 @@ leaf %>%
 #'
 #'
 #' ### Numeric
-numpal <- colorNumeric(rev(viridis::viridis(256)), spdf$POPDENSITY)
+numpal <- colorNumeric(rev(viridisLite::viridis(256)), spdf$POPDENSITY)
 
 leaf %>%
   addPolygons(weight = 1, color = "#333333", fillOpacity = 1,


### PR DESCRIPTION
## Pull Request

Since all the functions used by leaflet from viridis are reexported from viridisLite.

This reduces the total number of leaflet dependencies from 64 to 49.

PR task list:
- [x] Update NEWS
- [x] Add tests (where appropriate)
  - R code tests: `tests/testthat/`
  - Visual tests: `R/zzz_viztest.R`
- [x] Update documentation with `devtools::document()`
