### PR TITLE
feat: Expand available `{viridis}` palettes in `colorNumeric()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -81,5 +81,5 @@ Config/testthat/edition: 3
 Config/Needs/website: dplyr, geojsonio, ncdf4, tidyverse/tidytemplate
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # leaflet (development version)
 
+* Color palette improvements. All color palette functions now support all `{viridisLite}` palettes ("magma", "inferno", "plasma", "viridis", "cividis", "rocket", "mako", and "turbo").
+
 # leaflet 2.2.2
 
 * Fixed #893: Correctly call `terra::crs()` when checking the CRS of a `SpatVector` object in `pointData()` or `polygonData()` (thanks @mkoohafkan, #894).

--- a/R/colors.R
+++ b/R/colors.R
@@ -251,7 +251,7 @@ colorFactor <- function(palette, domain, levels = NULL, ordered = FALSE,
 #' \enumerate{
 #'   \item{A character vector of RGB or named colors. Examples: `palette()`, `c("#000000", "#0000FF", "#FFFFFF")`, `topo.colors(10)`}
 #'   \item{The name of an RColorBrewer palette, e.g. `"BuPu"` or `"Greens"`.}
-#'   \item{The full name of a viridis palette: `"viridis"`, `"magma"`, `"inferno"`, or `"plasma"`.}
+#'   \item{The full name of a viridis palette: `"magma"`, `"inferno"`, `"plasma"`, `"viridis"`, `"cividis"`, `"rocket"`, `"mako"`, or `"turbo"`}
 #'   \item{A function that receives a single value between 0 and 1 and returns a color. Examples: `colorRamp(c("#000000", "#FFFFFF"), interpolate = "spline")`.}
 #' }
 #' @examples
@@ -330,7 +330,17 @@ toPaletteFunc.character <- function(pal, alpha, nlevels) {
     } else {
       colors <- brewer_pal(pal) # Get all colors
     }
-  } else if (length(pal) == 1 && pal %in% c("viridis", "magma", "inferno", "plasma")) {
+  } else if (length(pal) == 1 &&
+             pal %in% c(
+               "magma",
+               "inferno",
+               "plasma",
+               "viridis",
+               "cividis",
+               "rocket",
+               "mako",
+               "turbo"
+             )) {
     colors <- viridisLite::viridis(n = 256, option = pal)
   } else {
     colors <- pal

--- a/man/colorNumeric.Rd
+++ b/man/colorNumeric.Rd
@@ -125,7 +125,7 @@ The \code{palette} argument can be any of the following:
 \enumerate{
 \item{A character vector of RGB or named colors. Examples: \code{palette()}, \code{c("#000000", "#0000FF", "#FFFFFF")}, \code{topo.colors(10)}}
 \item{The name of an RColorBrewer palette, e.g. \code{"BuPu"} or \code{"Greens"}.}
-\item{The full name of a viridis palette: \code{"viridis"}, \code{"magma"}, \code{"inferno"}, or \code{"plasma"}.}
+\item{The full name of a viridis palette: \code{"magma"}, \code{"inferno"}, \code{"plasma"}, \code{"viridis"}, \code{"cividis"}, \code{"rocket"}, \code{"mako"}, or \code{"turbo"}}
 \item{A function that receives a single value between 0 and 1 and returns a color. Examples: \code{colorRamp(c("#000000", "#FFFFFF"), interpolate = "spline")}.}
 }
 }

--- a/vignettes/articles/colors.Rmd
+++ b/vignettes/articles/colors.Rmd
@@ -35,7 +35,7 @@ The four color functions all have two required arguments, `palette` and `domain`
 The `palette` argument specifies the colors to map the data to. This argument can take one of several forms:
 
 1. The name of a preset palette from the `RColorBrewer` package, e.g. `"RdYlBu"`, `"Accent"`, or `"Greens"`.
-2. The full name of a `viridis` palette: `"viridis"`, `"magma"`, `"inferno"`, or `"plasma"`.
+2. The full name of a `viridis` palette: `"magma"`, `"inferno"`, `"plasma"`, `"viridis"`, `"cividis"`, `"rocket"`, `"mako"`, or `"turbo"`.
 3. A character vector of RGB or named colors, e.g. `palette()`, `c("#000000", "#0000FF", "#FFFFFF")`, `topo.colors(10)`.
 4. A function that receives a single value between 0 and 1 and returns a color, e.g.:
 `colorRamp(c("#000000", "#FFFFFF"), interpolate="spline")`


### PR DESCRIPTION
Since #897 `{leaflet}` uses `{viridisLite}`.

`colorNumeric()` only allows users to easily use four of the eight palettes available through `{viridisLite}`.

This PR allows the other four - turbo, mako, cividis, and rocket.

Slightly selfish PR in that I do like "turbo" for a not totally dreadful rainbow palette! Also I can't see a reason why only four of the eight palettes should be allowed / documented.

## Minimal reproducible example

``` r
devtools::load_all()
#> ℹ Loading leaflet

pal <- colorNumeric("turbo", breweries91$founded)

leaflet(breweries91) |>
  addTiles() |>
  addCircleMarkers(color = ~ pal(founded)) |>
  addLegend(pal = pal,
            values = breweries91$founded)
```

![](https://i.imgur.com/EqpSnyx.png)<!-- -->

<sup>Created on 2024-07-25 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

PR task list:
- [x] Update NEWS
- [x] Update documentation with `devtools::document()`

No current tests for different viridisLite palettes, so no tests added.