### PR TITLE
docs: Add pkgdown function reference page

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -81,5 +81,5 @@ Config/testthat/edition: 3
 Config/Needs/website: dplyr, geojsonio, ncdf4, tidyverse/tidytemplate
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)

--- a/R/data.R
+++ b/R/data.R
@@ -6,6 +6,7 @@
 #' @format A data frame containing `City`, `State`, `Lat`,
 #'   `Long`, and population estimates from 2000 to 2010 (columns
 #'   `Pop2000` to `Pop2010`).
+#' @family built in datasets
 #' @source The US Census Bureau:
 #'   <https://www.census.gov/data/datasets/time-series/demo/popest/intercensal-2000-2010-cities-and-towns.html>
 #' @noRd
@@ -32,6 +33,7 @@ if (file.exists("inst/csv/uspop2000.csv")) {
 #' @details This dataset contains storm tracks for selected storms
 #' in the Atlantic Ocean basin for the year 2005
 #' @format `sp::SpatialLinesDataFrame`
+#' @family built in datasets
 NULL
 
 #' @docType data
@@ -41,6 +43,7 @@ NULL
 #' @details This dataset comes from <https://gadm.org>.
 #' It was downloaded using [getData()].
 #' @format `sp::SpatialPolygonsDataFrame`
+#' @family built in datasets
 #' @source
 #' <https://gadm.org>
 NULL
@@ -55,4 +58,5 @@ NULL
 #' University of Marburg for a seminar called
 #' "The Geography of Beer, sustainability in the food industry"
 #' @format `sp::SpatialPointsDataFrame`
+#' @family built in datasets
 NULL

--- a/R/legacy.R
+++ b/R/legacy.R
@@ -7,6 +7,7 @@
 #' @param session,outputId Deprecated
 #'
 #' @rdname deprecated
+#' @keywords internal
 #' @export
 createLeafletMap <- function(session, outputId) {
 

--- a/man/atlStorms2005.Rd
+++ b/man/atlStorms2005.Rd
@@ -14,3 +14,9 @@ Atlantic Ocean storms 2005
 This dataset contains storm tracks for selected storms
 in the Atlantic Ocean basin for the year 2005
 }
+\seealso{
+Other built in datasets: 
+\code{\link{breweries91}},
+\code{\link{gadmCHE}}
+}
+\concept{built in datasets}

--- a/man/breweries91.Rd
+++ b/man/breweries91.Rd
@@ -16,3 +16,9 @@ subset of a larger database that was compiled by students at the
 University of Marburg for a seminar called
 "The Geography of Beer, sustainability in the food industry"
 }
+\seealso{
+Other built in datasets: 
+\code{\link{atlStorms2005}},
+\code{\link{gadmCHE}}
+}
+\concept{built in datasets}

--- a/man/deprecated.Rd
+++ b/man/deprecated.Rd
@@ -26,3 +26,4 @@ These functions are provided for backwards compatibility with the first
 iteration of the leaflet bindings
 (\url{https://github.com/jcheng5/leaflet-shiny}).
 }
+\keyword{internal}

--- a/man/gadmCHE.Rd
+++ b/man/gadmCHE.Rd
@@ -17,3 +17,9 @@ Administrative borders of Switzerland (level 1)
 This dataset comes from \url{https://gadm.org}.
 It was downloaded using \code{\link[=getData]{getData()}}.
 }
+\seealso{
+Other built in datasets: 
+\code{\link{atlStorms2005}},
+\code{\link{breweries91}}
+}
+\concept{built in datasets}

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -156,7 +156,3 @@ reference:
   desc: Spatial datasets exported by `{leaflet}`
   contents:
   - has_concept("built in datasets")
-
-- title: Deprecated
-  contents:
-  - createLeafletMap

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -71,3 +71,92 @@ redirects:
   - ["shiny.html", "articles/shiny.html"]
   - ["showhide.html", "articles/showhide.html"]
   - ["map_widget.html", "articles/widget.html"]
+
+reference:
+- title: The Map Widget
+  desc: The map widget and methods to manipulate it
+  contents:
+  - leaflet
+  - setView
+  - mapOptions
+  - leafletSizingPolicy
+
+- title: Graphics Elements
+  desc: Adding and removing grpahics
+  contents:
+  - addTiles
+  - tileOptions
+  - addProviderTiles
+  - providers
+  - addLegend
+  - addRasterImage
+  - addRasterLegend
+
+- title: Layers & Groups
+  desc: Control groups and switch layers on and off
+  contents:
+  - addMapPane
+  - addLayersControl
+  - showGroup
+  - groupOptions
+
+- title: Colors
+  desc: Map variables to colors
+  contents:
+  - colorFactor
+  - previewColors
+
+- title: Icons
+  desc: Use icons in `leaflet::addMarkers()`
+  contents:
+  - icons
+  - makeIcon
+  - iconList
+
+- title: Add-ons
+  desc: Utility functions to add additional functionality to a `{leaflet}` map
+- subtitle: Awesome Markers
+  contents:
+  - addAwesomeMarkers
+  - awesomeIcons
+  - makeAwesomeIcon
+  - awesomeIconList
+- subtitle: Other
+  contents:
+  - addMeasure
+  - addScaleBar
+  - addGraticule
+  - addSimpleGraticule
+  - addTerminator
+  - addMiniMap
+  - addEasyButton
+  - addEasyButtonBar
+
+- title: Shiny
+  desc: Using leaflet in `{shiny}`
+  contents:
+  - leafletOutput
+  - leafletProxy
+  - removeControl
+
+- title: Extending Leaflet
+  desc: Functions for extending leaflet
+  contents:
+  - derivePoints
+  - evalFormula
+  - expandLimits
+  - expandLimitsBbox
+  - filterNULL
+  - getMapData
+  - invokeMethod
+  - validateCoords
+  - leafletDependencies
+
+- title: Built in datasets
+  desc: Spatail datasets exported by `{leaflet}`
+  contents:
+  - has_concept("built in datasets")
+
+- title: Deprecated
+  contents:
+  - createLeafletMap

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -82,7 +82,7 @@ reference:
   - leafletSizingPolicy
 
 - title: Graphics Elements
-  desc: Adding and removing grpahics
+  desc: Adding and removing graphics
   contents:
   - addTiles
   - tileOptions
@@ -153,7 +153,7 @@ reference:
   - leafletDependencies
 
 - title: Built in datasets
-  desc: Spatail datasets exported by `{leaflet}`
+  desc: Spatial datasets exported by `{leaflet}`
   contents:
   - has_concept("built in datasets")
 


### PR DESCRIPTION
Since #902 `{leaflet}` has used `{pkgdown}`

One page that wasn't touched was https://rstudio.github.io/leaflet/reference/index.html, which is a massive list of unsorted functions.

This PR attempts to sort them into an ordered list that makes them easier to parse.

It's likely not perfect, but a step in the right direction! I tried to use the articles as a bit of a guide as to how to link the functions thematically.

PR task list:
- News N/A
- Tests N/A
- [X] Update documentation with `devtools::document()`
