### PR TITLE
feat: check tile providers in `addProviderTiles()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Color palette improvements. All color palette functions now support all `{viridisLite}` palettes ("magma", "inferno", "plasma", "viridis", "cividis", "rocket", "mako", and "turbo").
 
-* `addProviderTiles()` will now error if the chosen `provider` does not match any currently loaded provider (by default, those in `providers`). This behaviour can be toggled off by setting the new `.check` argument to `FALSE` (@jack-davison, #929)
+* `addProviderTiles()` will now error if the chosen `provider` does not match any currently loaded provider (by default, those in `providers`). This behaviour can be toggled off by setting the new `check` argument to `FALSE` (@jack-davison, #929)
 
 # leaflet 2.2.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Color palette improvements. All color palette functions now support all `{viridisLite}` palettes ("magma", "inferno", "plasma", "viridis", "cividis", "rocket", "mako", and "turbo").
 
+* `addProviderTiles()` will now error if the chosen `provider` does not match any currently loaded provider (by default, those in `providers`). This behaviour can be toggled off by setting the new `.check` argument to `FALSE` (@jack-davison, #929)
+
 # leaflet 2.2.2
 
 * Fixed #893: Correctly call `terra::crs()` when checking the CRS of a `SpatVector` object in `pointData()` or `polygonData()` (thanks @mkoohafkan, #894).

--- a/R/plugin-providers.R
+++ b/R/plugin-providers.R
@@ -22,7 +22,7 @@ leafletProviderDependencies <- function() {
 #'   (for [clearGroup()] and [addLayersControl()] purposes). Human-friendly
 #'   group names are permitted--they need not be short, identifier-style names.
 #' @param options tile options
-#' @param .check Check that the specified `provider` matches the available
+#' @param check Check that the specified `provider` matches the available
 #'   currently loaded leaflet providers? Defaults to `TRUE`, but can be toggled
 #'   to `FALSE` for advanced users.
 #' @return modified map object
@@ -39,16 +39,15 @@ addProviderTiles <- function(
   layerId = NULL,
   group = NULL,
   options = providerTileOptions(),
-  ...,
-  .check = TRUE
+  check = TRUE
 ) {
-  if (.check) {
+  if (check) {
     loaded_providers <- leaflet.providers::providers_loaded()
     if (!provider %in% names(loaded_providers$providers)) {
       stop(
         "Unknown tile provider '",
         provider,
-        "'; either use a known provider or pass `.check = FALSE` to `addProviderTiles()`"
+        "'; either use a known provider or pass `check = FALSE` to `addProviderTiles()`"
       )
     }
   }
@@ -61,7 +60,7 @@ addProviderTiles <- function(
 #' errorTileUrl,noWrap,opacity,zIndex,updateWhenIdle,detectRetina
 #' the tile layer options; see
 #' <https://web.archive.org/web/20220702182250/https://leafletjs.com/reference-1.3.4.html#tilelayer>
-#' @param ... For [providerTileOptions()], named parameters to add to the options. Not used in [addProviderTiles()].
+#' @param ... named parameters to add to the options
 #' @rdname addProviderTiles
 #' @export
 providerTileOptions <- function(errorTileUrl = "", noWrap = FALSE,

--- a/R/plugin-providers.R
+++ b/R/plugin-providers.R
@@ -45,7 +45,11 @@ addProviderTiles <- function(
   if (.check) {
     loaded_providers <- leaflet.providers::providers_loaded()
     if (!provider %in% names(loaded_providers$providers)) {
-      stop("Unknown tile provider '", provider, "; either use a known provider or pass `.check = FALSE` to `addProviderTiles()`')
+      stop(
+        "Unknown tile provider '",
+        provider,
+        "'; either use a known provider or pass `.check = FALSE` to `addProviderTiles()`"
+      )
     }
   }
   map$dependencies <- c(map$dependencies, leafletProviderDependencies())

--- a/R/plugin-providers.R
+++ b/R/plugin-providers.R
@@ -19,10 +19,13 @@ leafletProviderDependencies <- function() {
 #'   <https://github.com/leaflet-extras/leaflet-providers>)
 #' @param layerId the layer id to assign
 #' @param group the name of the group the newly created layers should belong to
-#'   (for [clearGroup()] and [addLayersControl()] purposes).
-#'   Human-friendly group names are permitted--they need not be short,
-#'   identifier-style names.
+#'   (for [clearGroup()] and [addLayersControl()] purposes). Human-friendly
+#'   group names are permitted--they need not be short, identifier-style names.
 #' @param options tile options
+#' @param ... Not currently used
+#' @param .check Check that the specified `provider` matches the available
+#'   currently loaded leaflet providers? Defaults to `TRUE`, but can be toggled
+#'   to `FALSE` for advanced users.
 #' @return modified map object
 #'
 #' @examples
@@ -36,8 +39,18 @@ addProviderTiles <- function(
   provider,
   layerId = NULL,
   group = NULL,
-  options = providerTileOptions()
+  options = providerTileOptions(),
+  ...,
+  .check = TRUE
 ) {
+  if (.check) {
+    loaded_providers <- leaflet.providers::providers_loaded()
+    provider <- match.arg(
+      arg = provider,
+      choices = unlist(use.names = FALSE, loaded_providers$providers),
+      several.ok = FALSE
+    )
+  }
   map$dependencies <- c(map$dependencies, leafletProviderDependencies())
   invokeMethod(map, getMapData(map), "addProviderTiles",
     provider, layerId, group, options)

--- a/R/plugin-providers.R
+++ b/R/plugin-providers.R
@@ -44,11 +44,9 @@ addProviderTiles <- function(
 ) {
   if (.check) {
     loaded_providers <- leaflet.providers::providers_loaded()
-    provider <- match.arg(
-      arg = provider,
-      choices = unlist(use.names = FALSE, loaded_providers$providers),
-      several.ok = FALSE
-    )
+    if (!provider %in% names(loaded_providers$providers)) {
+      stop("Unknown tile provider '", provider, "; either use a known provider or pass `.check = FALSE` to `addProviderTiles()`')
+    }
   }
   map$dependencies <- c(map$dependencies, leafletProviderDependencies())
   invokeMethod(map, getMapData(map), "addProviderTiles",

--- a/R/plugin-providers.R
+++ b/R/plugin-providers.R
@@ -22,7 +22,6 @@ leafletProviderDependencies <- function() {
 #'   (for [clearGroup()] and [addLayersControl()] purposes). Human-friendly
 #'   group names are permitted--they need not be short, identifier-style names.
 #' @param options tile options
-#' @param ... Not currently used
 #' @param .check Check that the specified `provider` matches the available
 #'   currently loaded leaflet providers? Defaults to `TRUE`, but can be toggled
 #'   to `FALSE` for advanced users.
@@ -60,7 +59,7 @@ addProviderTiles <- function(
 #' errorTileUrl,noWrap,opacity,zIndex,updateWhenIdle,detectRetina
 #' the tile layer options; see
 #' <https://web.archive.org/web/20220702182250/https://leafletjs.com/reference-1.3.4.html#tilelayer>
-#' @param ... named parameters to add to the options
+#' @param ... For [providerTileOptions()], named parameters to add to the options. Not used in [addProviderTiles()].
 #' @rdname addProviderTiles
 #' @export
 providerTileOptions <- function(errorTileUrl = "", noWrap = FALSE,

--- a/man/addProviderTiles.Rd
+++ b/man/addProviderTiles.Rd
@@ -40,7 +40,7 @@ group names are permitted--they need not be short, identifier-style names.}
 
 \item{options}{tile options}
 
-\item{...}{named parameters to add to the options}
+\item{...}{For \code{\link[=providerTileOptions]{providerTileOptions()}}, named parameters to add to the options. Not used in \code{\link[=addProviderTiles]{addProviderTiles()}}.}
 
 \item{.check}{Check that the specified \code{provider} matches the available
 currently loaded leaflet providers? Defaults to \code{TRUE}, but can be toggled

--- a/man/addProviderTiles.Rd
+++ b/man/addProviderTiles.Rd
@@ -10,7 +10,9 @@ addProviderTiles(
   provider,
   layerId = NULL,
   group = NULL,
-  options = providerTileOptions()
+  options = providerTileOptions(),
+  ...,
+  .check = TRUE
 )
 
 providerTileOptions(
@@ -33,16 +35,19 @@ providerTileOptions(
 \item{layerId}{the layer id to assign}
 
 \item{group}{the name of the group the newly created layers should belong to
-(for \code{\link[=clearGroup]{clearGroup()}} and \code{\link[=addLayersControl]{addLayersControl()}} purposes).
-Human-friendly group names are permitted--they need not be short,
-identifier-style names.}
+(for \code{\link[=clearGroup]{clearGroup()}} and \code{\link[=addLayersControl]{addLayersControl()}} purposes). Human-friendly
+group names are permitted--they need not be short, identifier-style names.}
 
 \item{options}{tile options}
 
+\item{...}{named parameters to add to the options}
+
+\item{.check}{Check that the specified \code{provider} matches the available
+currently loaded leaflet providers? Defaults to \code{TRUE}, but can be toggled
+to \code{FALSE} for advanced users.}
+
 \item{errorTileUrl, noWrap, opacity, zIndex, updateWhenIdle, detectRetina}{the tile layer options; see
 \url{https://web.archive.org/web/20220702182250/https://leafletjs.com/reference-1.3.4.html#tilelayer}}
-
-\item{...}{named parameters to add to the options}
 }
 \value{
 modified map object

--- a/man/addProviderTiles.Rd
+++ b/man/addProviderTiles.Rd
@@ -11,8 +11,7 @@ addProviderTiles(
   layerId = NULL,
   group = NULL,
   options = providerTileOptions(),
-  ...,
-  .check = TRUE
+  check = TRUE
 )
 
 providerTileOptions(
@@ -40,14 +39,14 @@ group names are permitted--they need not be short, identifier-style names.}
 
 \item{options}{tile options}
 
-\item{...}{For \code{\link[=providerTileOptions]{providerTileOptions()}}, named parameters to add to the options. Not used in \code{\link[=addProviderTiles]{addProviderTiles()}}.}
-
-\item{.check}{Check that the specified \code{provider} matches the available
+\item{check}{Check that the specified \code{provider} matches the available
 currently loaded leaflet providers? Defaults to \code{TRUE}, but can be toggled
 to \code{FALSE} for advanced users.}
 
 \item{errorTileUrl, noWrap, opacity, zIndex, updateWhenIdle, detectRetina}{the tile layer options; see
 \url{https://web.archive.org/web/20220702182250/https://leafletjs.com/reference-1.3.4.html#tilelayer}}
+
+\item{...}{named parameters to add to the options}
 }
 \value{
 modified map object

--- a/tests/testthat/test-tiles.R
+++ b/tests/testthat/test-tiles.R
@@ -1,0 +1,14 @@
+
+testthat::test_that("Checking of tile providers works correctly", {
+  expect_no_error(
+    leaflet() %>% addProviderTiles("OpenStreetMap")
+  )
+
+  expect_no_error(
+    leaflet() %>% addProviderTiles("FAKETILESET123", .check = FALSE)
+  )
+
+  expect_error(
+    leaflet() %>% addProviderTiles("FAKETILESET123")
+  )
+})

--- a/tests/testthat/test-tiles.R
+++ b/tests/testthat/test-tiles.R
@@ -1,7 +1,7 @@
 
 testthat::test_that("Checking of tile providers works correctly", {
   expect_no_error(
-    leaflet() %>% addProviderTiles("OpenStreetMap")
+    leaflet() %>% addProviderTiles(providers[[1]])
   )
 
   expect_no_error(

--- a/tests/testthat/test-tiles.R
+++ b/tests/testthat/test-tiles.R
@@ -5,7 +5,7 @@ testthat::test_that("Checking of tile providers works correctly", {
   )
 
   expect_no_error(
-    leaflet() %>% addProviderTiles("FAKETILESET123", .check = FALSE)
+    leaflet() %>% addProviderTiles("FAKETILESET123", check = FALSE)
   )
 
   expect_error(


### PR DESCRIPTION
Fixes #921
Fixes #677

In short, it adds the `.check` arg to `addProviderTiles()`, which defaults to `TRUE`. When `TRUE`, if a user mistakenly provides a provider not in `leaflet.providers::providers_loaded()`, the function will error.

Also adds a test to check this new argument is working as it should.

PR task list:
- [x] Update NEWS
- [X] Add tests (where appropriate)
  - R code tests: `tests/testthat/`
  - Visual tests: `R/zzz_viztest.R`
- [X] Update documentation with `devtools::document()`
