### PR TITLE
docs: change (broken) Bing maps example to heatmap in {pkgdown} site

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,6 @@
 
 * Updated vignettes to replace `{sp}`/`{raster}` usage with `{sf}`/`{terra}` and their corresponding examples. (@jack-davison, #928)
 
-* Updated vignettes to replace `{sp}`/`{raster}` usage with `{sf}`/`{terra} and their corresponding examples. (@jack-davison, #928)
-
 * `addProviderTiles()` will now error if the chosen `provider` does not match any currently loaded provider (by default, those in `providers`). This behaviour can be toggled off by setting the new `check` argument to `FALSE` (@jack-davison, #929)
 
 # leaflet 2.2.2

--- a/vignettes/articles/extending.Rmd
+++ b/vignettes/articles/extending.Rmd
@@ -43,31 +43,42 @@ Often when passing a list from R to JavaScript it is desirable to remove any nul
 
 # Example
 
-Here is a small example which shows how you can integrate the Bing.com basemap layer [plugin](https://github.com/shramov/leaflet-plugins)
+Here is a small example which shows how you can integrate heatmap functionality using a [plugin](http://leaflet.github.io/Leaflet.heat/).
 
 ```{r, fig.height=4}
 library(leaflet)
 library(htmltools)
 library(htmlwidgets)
 
-bingPlugin <- htmlDependency(
-  "leaflet.plugins", "2.0.0",
-  src = normalizePath("./js"),
-  script = "Bing.min.js"
+# This tells htmlwidgets about our plugin name, version, and
+# where to find the script. (There's also a stylesheet argument
+# if the plugin comes with CSS files.)
+heatPlugin <- htmlDependency(
+  "Leaflet.heat",
+  "99.99.99",
+  src = c(href = "http://leaflet.github.io/Leaflet.heat/dist/"),
+  script = "leaflet-heat.js"
 )
 
+# A function that takes a plugin htmlDependency object and adds
+# it to the map. This ensures that however or whenever the map
+# gets rendered, the plugin will be loaded into the browser.
 registerPlugin <- function(map, plugin) {
   map$dependencies <- c(map$dependencies, list(plugin))
   map
 }
 
-leaflet() %>% setView(-122.23, 37.75, zoom = 10) %>%
-  registerPlugin(bingPlugin) %>%
-  onRender("function(el, x) {
-    var imagerySet = 'Aerial';
-    var bing = new L.BingLayer('LfO3DMI9S6GnXD7d0WGs~bq2DRVkmIAzSOFdodzZLvw~Arx8dclDxmZA0Y38tHIJlJfnMbGq5GXeYmrGOUIbS2VLFzRKCK0Yv_bAl6oe-DOc',
-         {type: imagerySet});
-     this.addLayer(bing);
- }")
+# initialise leaflet map in R
+leaflet() %>%
+  addTiles() %>%
+  fitBounds(min(quakes$long), min(quakes$lat), max(quakes$long), max(quakes$lat)) %>%
+  # Register heatmap plugin on this map instance
+  registerPlugin(heatPlugin) %>%
+  # Add custom JS logic; `this` refers to the Leaflet (JS) map object.
+  onRender("function(el, x, data) {
+    data = HTMLWidgets.dataframeToD3(data);
+    data = data.map(function(val) { return [val.lat, val.long, val.mag*100]; });
+    L.heatLayer(data, {radius: 25}).addTo(this);
+  }", data = quakes[c("lat", "long", "mag")])
 ```
 


### PR DESCRIPTION
Fixes #927

Briefly, this replaces the now-broken Bing 'extending Leaflet' example [here](https://rstudio.github.io/leaflet/articles/extending.html#example) with the heatmap one found at: https://gist.github.com/jcheng5/c084a59717f18e947a17955007dc5f92

Also removes a duplicate NEWs item.

Example now looks like this:

![image](https://github.com/user-attachments/assets/aa183d3a-e8b8-4d8a-859e-dd495378fcc5)
