### PR TITLE
Open attribution links in new tab

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # leaflet (development version)
 
+* Attribution links for OpenStreetMap, OpenDataCommons, CartoDB, NASA, Kadaster, Kartena will now open in a new tab (using the HTML <a> `target` attribute)
+
 * `{leaflet}` no longer install sp by default and attempts to convert object to sf internally before creating a map and warns when it fails conversion (@olivroy, #942).
 
 * The `breweries91`, `atlStorms2005`, and `gadmCHE` datasets are now `{sf}` objects (@olivroy, #944).

--- a/R/layers.R
+++ b/R/layers.R
@@ -166,8 +166,8 @@ addTiles <- function(
   options$attribution <- attribution
   if (missing(urlTemplate) && is.null(options$attribution))
     options$attribution <- paste(
-      "&copy; <a href=\"https://openstreetmap.org/copyright/\">OpenStreetMap</a>, ",
-      "<a href=\"https://opendatacommons.org/licenses/odbl/\">ODbL</a>"
+      "&copy; <a href=\"https://openstreetmap.org/copyright/\" target=\"_blank\">OpenStreetMap</a>, ",
+      "<a href=\"https://opendatacommons.org/licenses/odbl/\" target=\"_blank\">ODbL</a>"
     )
   invokeMethod(map, data, "addTiles", urlTemplate, layerId, group,
     options)

--- a/R/legacy.R
+++ b/R/legacy.R
@@ -100,8 +100,8 @@ leafletMap <- function(
 
   if (missing(initialTileLayer) && is.null(initialTileLayerAttribution))
     initialTileLayerAttribution <- paste(
-      "&copy; <a href=\"https://openstreetmap.org\">OpenStreetMap</a>",
-      "contributors, <a href=\"https://creativecommons.org/licenses/by-sa/2.0/\">CC-BY-SA</a>"
+      "&copy; <a href=\"https://openstreetmap.org\" target=\"_blank\">OpenStreetMap</a>",
+      "contributors, <a href=\"https://creativecommons.org/licenses/by-sa/2.0/\" target=\"_blank\">CC-BY-SA</a>"
     )
 
   shiny::addResourcePath("leaflet-legacy", system_file("legacy/www", package = "leaflet"))

--- a/inst/examples/leaflet.R
+++ b/inst/examples/leaflet.R
@@ -125,8 +125,8 @@ m %>% setView(-122.36075812146, 47.6759920119894, zoom = 13) %>% addGeoJSON(seat
 # use the Dark Matter layer from CartoDB
 leaflet() %>% addTiles("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
   attribution = paste(
-    "&copy; <a href=\"https://openstreetmap.org\">OpenStreetMap</a> contributors",
-    "&copy; <a href=\"https://cartodb.com/attributions\">CartoDB</a>"
+    "&copy; <a href=\"https://openstreetmap.org\" target=\"_blank\">OpenStreetMap</a> contributors",
+    "&copy; <a href=\"https://cartodb.com/attributions\" target=\"_blank\">CartoDB</a>"
   )
 ) %>% setView(-122.36, 47.67, zoom = 10)
 

--- a/inst/examples/proj4Leaflet-PolarProjections.R
+++ b/inst/examples/proj4Leaflet-PolarProjections.R
@@ -124,7 +124,10 @@ leaflet(options = leafletOptions(
   addCircleMarkers(data = points, label = ~Name) %>%
   addTiles(urlTemplate = antarticaTilesURL,
            layerId = "antartica_tiles",
-           attribution = "<a href='https://earthdata.nasa.gov/gibs'> NASA EOSDIS GIBS</a>&nbsp;&nbsp;&nbsp; <a href='https://github.com/nasa-gibs/web-examples/blob/release/leaflet/js/antarctic-epsg3031.js'> View Source </a>",
+           attribution = paste(
+             "<a href='https://earthdata.nasa.gov/gibs' target='_blank'> NASA EOSDIS GIBS</a>&nbsp;&nbsp;&nbsp;",
+             "<a href='https://github.com/nasa-gibs/web-examples/blob/release/leaflet/js/antarctic-epsg3031.js'  target='_blank'> View Source </a>"
+             ),
            options = tileOptions(
              tileSize = 512,
              subdomains = "abc",

--- a/inst/examples/proj4Leaflet-TMS.R
+++ b/inst/examples/proj4Leaflet-TMS.R
@@ -38,7 +38,7 @@ leaflet(options = leafletOptions(
   addTiles("http://geodata.nationaalgeoregister.nl/tms/1.0.0/brtachtergrondkaart/{z}/{x}/{y}.png",
            options = tileOptions(tms = TRUE,
                                  errorTileUrl = "http://www.webmapper.net/theme/img/missing-tile.png"),
-           attribution = "Map data: <a href=\"http://www.kadaster.nl\">Kadaster</a>") %>%
+           attribution = "Map data: <a href=\"http://www.kadaster.nl\" target=\"_blank\">Kadaster</a>") %>%
   addCircleMarkers(data = meuse.4326, popup = popupTable(meuse))
 
 

--- a/inst/examples/proj4Leaflet.R
+++ b/inst/examples/proj4Leaflet.R
@@ -30,7 +30,7 @@ leaflet(
       )) %>%
   addTiles(
     urlTemplate = "https://api.geosition.com/tile/osm-bright-3006/{z}/{x}/{y}.png",
-    attribution = "Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap contributors</a>, Imagery &copy; 2013 <a href=\"http://www.kartena.se/\">Kartena</a>",
+    attribution = "Map data &copy; <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">OpenStreetMap contributors</a>, Imagery &copy; 2013 <a href=\"http://www.kartena.se/\" target=\"_blank\">Kartena</a>",
     options = tileOptions(minZoom = 0, maxZoom = 14)) %>%
   setView(11.965, 57.704, 13)
 

--- a/inst/legacy/examples/population/ui.R
+++ b/inst/legacy/examples/population/ui.R
@@ -6,7 +6,7 @@ shinyUI(fluidPage(
   leafletMap(
     "map", "100%", 400,
     initialTileLayer = "//{s}.tiles.mapbox.com/v3/jcheng.map-5ebohr46/{z}/{x}/{y}.png",
-    initialTileLayerAttribution = HTML("Maps by <a href=\"http://www.mapbox.com/\">Mapbox</a>"),
+    initialTileLayerAttribution = HTML("Maps by <a href=\"http://www.mapbox.com/\" target=\"_blank\">Mapbox</a>"),
     options = list(
       center = c(37.45, -93.85),
       zoom = 4,

--- a/man/leaflet.Rd
+++ b/man/leaflet.Rd
@@ -251,8 +251,8 @@ m \%>\% setView(-122.36075812146, 47.6759920119894, zoom = 13) \%>\% addGeoJSON(
 # use the Dark Matter layer from CartoDB
 leaflet() \%>\% addTiles("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
   attribution = paste(
-    "&copy; <a href=\"https://openstreetmap.org\">OpenStreetMap</a> contributors",
-    "&copy; <a href=\"https://cartodb.com/attributions\">CartoDB</a>"
+    "&copy; <a href=\"https://openstreetmap.org\" target=\"_blank\">OpenStreetMap</a> contributors",
+    "&copy; <a href=\"https://cartodb.com/attributions\" target=\"_blank\">CartoDB</a>"
   )
 ) \%>\% setView(-122.36, 47.67, zoom = 10)
 


### PR DESCRIPTION
Adds `target='blank'` to attributtion <a> elements for OpenStreetMap, CartoDB and others. Closes #940 

PR task list:
- [x ] Update NEWS
- [x ] Update documentation with `devtools::document()`
